### PR TITLE
Create Contact and Address entities, embed them in organisation entity

### DIFF
--- a/assets/js/Components/EmbedForm.js
+++ b/assets/js/Components/EmbedForm.js
@@ -1,0 +1,45 @@
+'use strict';
+
+import $ from 'jquery';
+
+class EmbedForm {
+    /**
+     * @constructor
+     *
+     * @param {jQuery} $prototypeContainer - The form container with data-prototype
+     * @param {Array} options
+     *                  $addButton (optional) custom Add button
+     *                  $itemWrapper (optional) custom wrapper to wrap all added items
+     */
+    constructor($prototypeContainer, options = {}) {
+        $prototypeContainer.data('index', $prototypeContainer.find(':input').length);
+
+        if (!options.$addButton) {
+            options.$addButton = $('<button type="button" class="btn btn-primary">Add</button>');
+        }
+
+        if (!options.$itemWrapper) {
+            options.$itemWrapper = $('<fieldset class="form-group"></fieldset>');
+        }
+
+        options.$addButton.on('click', function (e) {
+            EmbedForm.addPrototypedItem($prototypeContainer, options);
+        });
+
+        EmbedForm.addPrototypedItem($prototypeContainer, options);
+
+        $prototypeContainer.after(options.$addButton);
+    }
+
+    static addPrototypedItem($prototypeContainer, options) {
+        var prototype = $prototypeContainer.data('prototype');
+        var index = $prototypeContainer.data('index');
+
+        var newForm = prototype.replace(/__name__/g, index);
+        $prototypeContainer.data('index', index + 1);
+
+        $prototypeContainer.append(options.$itemWrapper.clone().append(newForm));
+    }
+}
+
+export default EmbedForm;

--- a/assets/js/contact/edit.js
+++ b/assets/js/contact/edit.js
@@ -1,0 +1,11 @@
+'use strict';
+
+import $ from 'jquery';
+import EmbedForm from '../Components/EmbedForm';
+
+$(function () {
+    new EmbedForm($('.contact-addresses'), {
+        $addButton: $('<button type="button" class="btn btn-primary">Add address</button>'),
+        $itemWrapper: $('<fieldset class="form-group"><legend class="col-form-label">Address</legend></fieldset>')
+    });
+});

--- a/src/DataFixtures/AddressFixtures.php
+++ b/src/DataFixtures/AddressFixtures.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\Persistence\ObjectManager;
+use Faker\Factory as Faker;
+use App\Entity\Address;
+
+class AddressFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $faker = Faker::create();
+
+        for ($i = 0; $i < 20; $i++) {
+            $address = new Address();
+
+            $address
+                ->setName($faker->word)
+                ->setStreetAddress($faker->streetAddress)
+                ->setStreetAddressComplementary($faker->secondaryAddress)
+                ->setPostalCode($faker->postcode)
+                ->setCity($faker->city)
+            ;
+
+            $this->setReference("address-$i", $address);
+            $manager->persist($address);
+        }
+
+        $manager->flush();
+    }
+}

--- a/src/DataFixtures/ContactFixtures.php
+++ b/src/DataFixtures/ContactFixtures.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Faker\Factory as Faker;
+use App\Entity\Contact;
+
+class ContactFixtures extends Fixture implements DependentFixtureInterface
+{
+    public function load(ObjectManager $manager): void
+    {
+        $faker = Faker::create();
+
+        $nextAddress = 0;
+
+        for ($i = 0; $i < 10; $i++) {
+            $contact = new Contact();
+
+            $contact
+                ->setFirstName($faker->firstName)
+                ->setLastName($faker->lastName)
+                ->setEmail($faker->email)
+                ->setPhoneNumber($faker->phoneNumber)
+            ;
+
+            if ($faker->boolean) {
+                $contact->addAddress($this->getReference('address-'.($nextAddress++)));
+            }
+            if ($faker->boolean) {
+                $contact->addAddress($this->getReference('address-'.($nextAddress++)));
+            }
+
+            $this->setReference("contact-$i", $contact);
+            $manager->persist($contact);
+        }
+
+        $manager->flush();
+    }
+
+    public function getDependencies()
+    {
+        return [
+            AddressFixtures::class,
+        ];
+    }
+}

--- a/src/DataFixtures/OrganisationFixtures.php
+++ b/src/DataFixtures/OrganisationFixtures.php
@@ -7,10 +7,11 @@ namespace App\DataFixtures;
 use App\Entity\Organisation;
 use App\Repository\Organisation\OrganisationRepositoryInterface;
 use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Faker\Factory as Faker;
 
-final class OrganisationFixtures extends Fixture
+final class OrganisationFixtures extends Fixture implements DependentFixtureInterface
 {
     private $repository;
 
@@ -27,12 +28,10 @@ final class OrganisationFixtures extends Fixture
             $organisation = new Organisation(
                 $this->repository->nextIdentity(),
                 $faker->company,
-                "http://{$faker->domainName}"
+                "http://{$faker->domainName}",
+                $this->getReference("contact-$i")
             );
 
-            if ($faker->boolean) {
-                $organisation->setAddress($faker->address);
-            }
             if ($faker->boolean) {
                 $organisation->setComment($faker->sentence);
             }
@@ -41,5 +40,12 @@ final class OrganisationFixtures extends Fixture
         }
 
         $manager->flush();
+    }
+
+    public function getDependencies()
+    {
+        return [
+            ContactFixtures::class,
+        ];
     }
 }

--- a/src/Dto/AddressRequest.php
+++ b/src/Dto/AddressRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\Entity\Address;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class AddressRequest
+{
+    /**
+     * @Assert\NotBlank()
+     */
+    public $streetAddress;
+
+    public $streetAddressComplementary;
+
+    /**
+     * @Assert\NotBlank()
+     */
+    public $postalCode;
+
+    /**
+     * @Assert\NotBlank()
+     */
+    public $city;
+
+    public static function createFromEntity(Address $address): AddressRequest
+    {
+        $addressRequest = new self();
+        $addressRequest->streetAddress = $address->getStreetAddress();
+        $addressRequest->streetAddressComplementary = $address->getStreetAddressComplementary();
+        $addressRequest->postalCode = $address->getPostalCode();
+        $addressRequest->city = $address->getCity();
+
+        return $addressRequest;
+    }
+
+    public function updateEntity(Address $address): void
+    {
+        $address->setStreetAddress($this->streetAddress);
+        $address->setStreetAddressComplementary($this->streetAddressComplementary);
+        $address->setPostalCode($this->postalCode);
+        $address->setCity($this->city);
+    }
+}

--- a/src/Dto/ContactRequest.php
+++ b/src/Dto/ContactRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\Entity\Contact;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final class ContactRequest
+{
+    /**
+     * @Assert\NotBlank()
+     */
+    public $firstName;
+
+    public $lastName;
+
+    /**
+     * @Assert\Email()
+     */
+    public $email;
+
+    public $phoneNumber;
+
+    public $addresses;
+
+    public static function createFromEntity(Contact $contact): ContactRequest
+    {
+        $contactRequest = new self();
+        $contactRequest->firstName = $contact->getFirstName();
+        $contactRequest->lastName = $contact->getLastName();
+        $contactRequest->email = $contact->getEmail();
+        $contactRequest->phoneNumber = $contact->getPhoneNumber();
+        $contactRequest->addresses = $contact->getAddresses();
+
+        return $contactRequest;
+    }
+
+    public function updateEntity(Contact $contact): void
+    {
+        $contact->setFirstName($this->firstName);
+        $contact->setLastName($this->lastName);
+        $contact->setEmail($this->email);
+        $contact->setPhoneNumber($this->phoneNumber);
+        $contact->setAddresses($this->addresses);
+    }
+}

--- a/src/Dto/OrganisationRequest.php
+++ b/src/Dto/OrganisationRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Dto;
 
+use App\Entity\Contact;
 use App\Entity\Organisation;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -20,15 +21,15 @@ final class OrganisationRequest
      */
     public $website;
 
-    public $address;
+    public $contact;
 
     public $comment;
 
-    public function __construct(string $name = null, string $website = null, string $address = null, string $comment = null)
+    public function __construct(string $name = null, string $website = null, Contact $contact = null, string $comment = null)
     {
         $this->name = $name;
         $this->website = $website;
-        $this->address = $address;
+        $this->contact = $contact;
         $this->comment = $comment;
     }
 
@@ -37,7 +38,7 @@ final class OrganisationRequest
         return new OrganisationRequest(
             $organisation->getName(),
             $organisation->getWebsite(),
-            $organisation->getAddress(),
+            $organisation->getContact(),
             $organisation->getComment()
         );
     }
@@ -46,7 +47,7 @@ final class OrganisationRequest
     {
         $organisation->setName($this->name);
         $organisation->setWebsite($this->website);
-        $organisation->setAddress($this->address);
+        $organisation->setContact($this->contact);
         $organisation->setComment($this->comment);
     }
 }

--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @ORM\Entity()
+ */
+class Address
+{
+    /**
+     * @ORM\Id()
+     * @ORM\Column(type="guid")
+     */
+    private $id;
+
+    /**
+     * Address name (Headquarter, personnal address...).
+     *
+     * @ORM\Column(type="string", length=63, nullable=true)
+     */
+    private $name;
+
+    /**
+     * @Assert\NotBlank()
+     * @ORM\Column(type="string", length=127)
+     */
+    private $streetAddress;
+
+    /**
+     * @ORM\Column(type="string", length=127, nullable=true)
+     */
+    private $streetAddressComplementary;
+
+    /**
+     * @Assert\NotBlank()
+     * @ORM\Column(type="string", length=15)
+     */
+    private $postalCode;
+
+    /**
+     * @Assert\NotBlank()
+     * @ORM\Column(type="string", length=63)
+     */
+    private $city;
+
+    public function __construct()
+    {
+        $this->id = Uuid::uuid4()->toString();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getStreetAddress(): ?string
+    {
+        return $this->streetAddress;
+    }
+
+    public function setStreetAddress(string $streetAddress): self
+    {
+        $this->streetAddress = $streetAddress;
+
+        return $this;
+    }
+
+    public function getStreetAddressComplementary(): ?string
+    {
+        return $this->streetAddressComplementary;
+    }
+
+    public function setStreetAddressComplementary(?string $streetAddressComplementary): self
+    {
+        $this->streetAddressComplementary = $streetAddressComplementary;
+
+        return $this;
+    }
+
+    public function getPostalCode(): ?string
+    {
+        return $this->postalCode;
+    }
+
+    public function setPostalCode(string $postalCode): self
+    {
+        $this->postalCode = $postalCode;
+
+        return $this;
+    }
+
+    public function getCity(): ?string
+    {
+        return $this->city;
+    }
+
+    public function setCity(string $city): self
+    {
+        $this->city = $city;
+
+        return $this;
+    }
+}

--- a/src/Entity/Contact.php
+++ b/src/Entity/Contact.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Ramsey\Uuid\Uuid;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @ORM\Entity()
+ */
+class Contact
+{
+    /**
+     * @ORM\Id()
+     * @ORM\Column(type="guid")
+     */
+    private $id;
+
+    /**
+     * @Assert\NotBlank()
+     * @ORM\Column(type="string", length=63)
+     */
+    private $firstName;
+
+    /**
+     * @Assert\NotBlank()
+     * @ORM\Column(type="string", length=63)
+     */
+    private $lastName;
+
+    /**
+     * @Assert\Email()
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $email;
+
+    /**
+     * @ORM\Column(type="string", length=31, nullable=true)
+     */
+    private $phoneNumber;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="App\Entity\Address", cascade={"persist", "remove"})
+     */
+    private $addresses;
+
+    public function __construct()
+    {
+        $this->id = Uuid::uuid4()->toString();
+        $this->addresses = new ArrayCollection();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getFirstName(): ?string
+    {
+        return $this->firstName;
+    }
+
+    public function setFirstName(string $firstName): self
+    {
+        $this->firstName = $firstName;
+
+        return $this;
+    }
+
+    public function getLastName(): ?string
+    {
+        return $this->lastName;
+    }
+
+    public function setLastName(?string $lastName): self
+    {
+        $this->lastName = $lastName;
+
+        return $this;
+    }
+
+    public function getEmail(): ?string
+    {
+        return $this->email;
+    }
+
+    public function setEmail(?string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    public function getPhoneNumber(): ?string
+    {
+        return $this->phoneNumber;
+    }
+
+    public function setPhoneNumber(?string $phoneNumber): self
+    {
+        $this->phoneNumber = $phoneNumber;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection|Address[]
+     */
+    public function getAddresses(): Collection
+    {
+        return $this->addresses;
+    }
+
+    public function setAddresses($addresses): Collection
+    {
+        $this->addresses = $addresses;
+
+        return $this;
+    }
+
+    public function addAddress(Address $address): self
+    {
+        if (!$this->addresses->contains($address)) {
+            $this->addresses[] = $address;
+        }
+
+        return $this;
+    }
+
+    public function removeAddress(Address $address): self
+    {
+        if ($this->addresses->contains($address)) {
+            $this->addresses->removeElement($address);
+        }
+
+        return $this;
+    }
+}

--- a/src/Entity/Organisation.php
+++ b/src/Entity/Organisation.php
@@ -33,21 +33,21 @@ class Organisation
     private $website;
 
     /**
-     * @ORM\Column(type="string", length=255, nullable=true)
+     * @ORM\ManyToOne(targetEntity="App\Entity\Contact", cascade={"persist"})
      */
-    private $address;
+    private $contact;
 
     /**
      * @ORM\Column(type="text", nullable=true)
      */
     private $comment;
 
-    public function __construct(UuidInterface $id, string $name, string $website, string $address = null, string $comment = null)
+    public function __construct(UuidInterface $id, string $name, string $website, Contact $contact = null, string $comment = null)
     {
         $this->id = $id->toString();
         $this->name = $name;
         $this->website = $website;
-        $this->address = $address;
+        $this->contact = $contact;
         $this->comment = $comment;
     }
 
@@ -80,14 +80,14 @@ class Organisation
         return $this;
     }
 
-    public function getAddress(): ?string
+    public function getContact(): ?Contact
     {
-        return $this->address;
+        return $this->contact;
     }
 
-    public function setAddress(?string $address): self
+    public function setContact(?Contact $contact): self
     {
-        $this->address = $address;
+        $this->contact = $contact;
 
         return $this;
     }

--- a/src/Form/AddressType.php
+++ b/src/Form/AddressType.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use App\Entity\Address;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class AddressType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'attr' => [
+                    'placeholder' => 'Example: Headquarter, Antenna...',
+                    'class' => 'form-control',
+                    'maxlength' => '63',
+                ],
+            ])
+            ->add('streetAddress', TextType::class, [
+                'required' => true,
+                'attr' => [
+                    'class' => 'form-control',
+                    'maxlength' => '127',
+                ],
+            ])
+            ->add('streetAddressComplementary', TextType::class, [
+                'attr' => [
+                    'class' => 'form-control',
+                    'maxlength' => '127',
+                ],
+            ])
+            ->add('postalCode', TextType::class, ['required' => true], [
+                'required' => true,
+                'attr' => [
+                    'class' => 'form-control',
+                    'maxlength' => '15',
+                ],
+            ])
+            ->add('city', TextType::class, ['required' => true], [
+                'required' => true,
+                'attr' => [
+                    'class' => 'form-control',
+                    'maxlength' => '63',
+                ],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Address::class,
+        ]);
+    }
+}

--- a/src/Form/ContactType.php
+++ b/src/Form/ContactType.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use App\Entity\Contact;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ContactType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('firstName', TextType::class, [
+                'required' => true,
+                'attr' => [
+                    'class' => 'form-control',
+                    'maxlength' => '63',
+                ],
+            ])
+            ->add('lastName', TextType::class, [
+                'required' => true,
+                'attr' => [
+                    'class' => 'form-control',
+                    'maxlength' => '63',
+                ],
+            ])
+            ->add('email', EmailType::class, [
+                'attr' => [
+                    'class' => 'form-control',
+                    'maxlength' => '255',
+                ],
+            ])
+            ->add('phoneNumber', TextType::class, [
+                'attr' => [
+                    'class' => 'form-control',
+                    'maxlength' => '31',
+                ],
+            ])
+            ->add('addresses', CollectionType::class, [
+                'entry_type' => AddressType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => Contact::class,
+        ]);
+    }
+}

--- a/src/Form/OrganisationType.php
+++ b/src/Form/OrganisationType.php
@@ -22,7 +22,7 @@ final class OrganisationType extends AbstractType
                 'required' => true,
                 'help' => 'Must start with http:// or https://',
             ])
-            ->add('address', TextType::class, ['required' => false])
+            ->add('contact', ContactType::class, ['required' => false])
             ->add('comment', TextareaType::class, ['required' => false])
         ;
     }

--- a/src/Migrations/Version20181204110357.php
+++ b/src/Migrations/Version20181204110357.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20181204110357 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $this->createTableAddress($schema);
+        $this->createTableContact($schema);
+        $this->createTableContactAddress($schema);
+        $this->modifyTableOrganisation($schema);
+    }
+
+    private function createTableAddress(Schema $schema): void
+    {
+        $schema->createSequence('address_id_seq');
+
+        $table = $schema->createTable('address');
+        $table->addColumn('id', Type::GUID);
+        $table->addColumn('name', Type::STRING, ['length' => 63]);
+        $table->addColumn('street_address', Type::STRING, ['length' => 127]);
+        $table->addColumn('street_address_complementary', Type::STRING, ['notnull' => false, 'length' => 127]);
+        $table->addColumn('postal_code', Type::STRING, ['length' => 15]);
+        $table->addColumn('city', Type::STRING, ['length' => 63]);
+
+        $table->setPrimaryKey(['id']);
+    }
+
+    private function createTableContact(Schema $schema): void
+    {
+        $schema->createSequence('contact_id_seq');
+
+        $table = $schema->createTable('contact');
+
+        $table->addColumn('id', Type::GUID);
+        $table->addColumn('first_name', Type::STRING, ['length' => 63]);
+        $table->addColumn('last_name', Type::STRING, ['length' => 63]);
+        $table->addColumn('email', Type::STRING, ['notnull' => false, 'length' => 255]);
+        $table->addColumn('phone_number', Type::STRING, ['length' => 31, 'notnull' => false]);
+
+        $table->setPrimaryKey(['id']);
+    }
+
+    private function createTableContactAddress(Schema $schema): void
+    {
+        $table = $schema->createTable('contact_address');
+
+        $table->addColumn('contact_id', Type::GUID);
+        $table->addColumn('address_id', Type::GUID);
+
+        $table->setPrimaryKey(['contact_id', 'address_id']);
+
+        $table->addForeignKeyConstraint('contact', ['contact_id'], ['id'], ['onDelete' => 'CASCADE']);
+        $table->addForeignKeyConstraint('address', ['address_id'], ['id'], ['onDelete' => 'CASCADE']);
+    }
+
+    private function modifyTableOrganisation(Schema $schema): void
+    {
+        $table = $schema->getTable('organisation');
+
+        $table->dropColumn('address');
+
+        $table->addColumn('contact_id', Type::GUID, ['notnull' => false]);
+        $table->addIndex(['contact_id']);
+        $table->addForeignKeyConstraint('contact', ['contact_id'], ['id']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->hasTable('address')) {
+            $schema->dropTable('address');
+            $schema->dropSequence('address_id_seq');
+        }
+
+        if ($schema->hasTable('contact')) {
+            $schema->dropTable('contact');
+            $schema->dropSequence('contact_id_seq');
+        }
+
+        if ($schema->hasTable('contact_address')) {
+            $schema->dropTable('contact_address');
+        }
+
+        $organisationTable = $schema->getTable('organisation');
+        $organisationTable->addColumn('address', Type::STRING, ['length' => 255, 'notnull' => false]);
+        $organisationTable->dropColumn('contact_id');
+    }
+}

--- a/src/Repository/AddressRepository.php
+++ b/src/Repository/AddressRepository.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Dto\AddressRequest;
+use App\Entity\Address;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+class AddressRepository implements AddressRepositoryInterface
+{
+    private $entityManager;
+    private $repository;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+        $this->repository = $entityManager->getRepository(Address::class);
+    }
+
+    public function save(Address $address): void
+    {
+        $this->entityManager->persist($address);
+        $this->entityManager->flush();
+    }
+
+    public function remove(Address $address): void
+    {
+        $this->entityManager->remove($address);
+        $this->entityManager->flush();
+    }
+
+    public function find(string $id): ?Address
+    {
+        return $this->repository->find($id);
+    }
+
+    public function findAll(): array
+    {
+        return $this->repository->findAll();
+    }
+
+    public function createFromRequest(AddressRequest $addressRequest): Address
+    {
+        $address = new Address();
+
+        return $address
+            ->setId($this->nextIdentity()->toString())
+            ->setStreetAddress($this->streetAddress)
+            ->setStreetAddressComplementary($this->streetAddressComplementary)
+            ->setPostalCode($this->postalCode)
+            ->setCity($this->city)
+        ;
+    }
+
+    public function createWith(
+        string $streetAddress,
+        string $streetAddressComplementary,
+        string $postalCode,
+        string $city
+    ): Address {
+        $address = new Address();
+
+        return $address
+            ->setId($this->nextIdentity()->toString())
+            ->setStreetAddress($streetAddress)
+            ->setStreetAddressComplementary($streetAddressComplementary)
+            ->setPostalCode($postalCode)
+            ->setCity($city)
+        ;
+    }
+
+    public function nextIdentity(): UuidInterface
+    {
+        return Uuid::uuid4();
+    }
+}

--- a/src/Repository/AddressRepositoryInterface.php
+++ b/src/Repository/AddressRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Dto\AddressRequest;
+use App\Entity\Address;
+use Ramsey\Uuid\UuidInterface;
+
+interface AddressRepositoryInterface
+{
+    public function save(Address $address): void;
+
+    public function find(string $id): ?Address;
+
+    public function remove(Address $address): void;
+
+    public function findAll(): array;
+
+    public function nextIdentity(): UuidInterface;
+
+    public function createFromRequest(AddressRequest $addressRequest): Address;
+}

--- a/src/Repository/ContactRepository.php
+++ b/src/Repository/ContactRepository.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Dto\ContactRequest;
+use App\Entity\Contact;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+class ContactRepository implements ContactRepositoryInterface
+{
+    private $entityManager;
+    private $repository;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+        $this->repository = $entityManager->getRepository(Contact::class);
+    }
+
+    public function save(Contact $contact): void
+    {
+        $this->entityManager->persist($contact);
+        $this->entityManager->flush();
+    }
+
+    public function remove(Contact $contact): void
+    {
+        $this->entityManager->remove($contact);
+        $this->entityManager->flush();
+    }
+
+    public function find(string $id): ?Contact
+    {
+        return $this->repository->find($id);
+    }
+
+    public function findAll(): array
+    {
+        return $this->repository->findAll();
+    }
+
+    public function createFromRequest(ContactRequest $contactRequest): Contact
+    {
+        $contact = new Contact();
+
+        return $contact
+            ->setId($this->nextIdentity()->toString())
+            ->setFirstName($this->firstName)
+            ->setLastName($this->lastName)
+            ->setEmail($this->email)
+            ->setPhoneNumber($this->phoneNumber)
+            ->setAddresses($this->addresses)
+        ;
+    }
+
+    public function createWith(
+        string $firstName,
+        string $lastName,
+        string $email,
+        string $phoneNumber,
+        string $addresses
+    ): Contact {
+        $contact = new Contact();
+
+        return $contact
+            ->setId($this->nextIdentity()->toString())
+            ->setFirstName($firstName)
+            ->setLastName($lastName)
+            ->setEmail($email)
+            ->setPhoneNumber($phoneNumber)
+            ->setAddresses($addresses)
+        ;
+    }
+
+    public function nextIdentity(): UuidInterface
+    {
+        return Uuid::uuid4();
+    }
+}

--- a/src/Repository/ContactRepositoryInterface.php
+++ b/src/Repository/ContactRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Dto\ContactRequest;
+use App\Entity\Contact;
+use Ramsey\Uuid\UuidInterface;
+
+interface ContactRepositoryInterface
+{
+    public function save(Contact $contact): void;
+
+    public function find(string $id): ?Contact;
+
+    public function remove(Contact $contact): void;
+
+    public function findAll(): array;
+
+    public function nextIdentity(): UuidInterface;
+
+    public function createFromRequest(ContactRequest $contactRequest): Contact;
+}

--- a/src/Repository/Organisation/DoctrineOrganisationRepository.php
+++ b/src/Repository/Organisation/DoctrineOrganisationRepository.php
@@ -37,7 +37,7 @@ final class DoctrineOrganisationRepository implements OrganisationRepositoryInte
             $this->nextIdentity(),
             $organisationRequest->name,
             $organisationRequest->website,
-            $organisationRequest->address,
+            $organisationRequest->contact,
             $organisationRequest->comment
         );
     }

--- a/templates/organisations/_edit_form.html.twig
+++ b/templates/organisations/_edit_form.html.twig
@@ -1,0 +1,28 @@
+{{ form_start(form) }}
+
+{{ form_row(form.name) }}
+{{ form_row(form.website) }}
+
+{% set addressPrototype = form_widget(form.contact.addresses.vars.prototype) %}
+
+{{ form_label(form.contact) }}
+
+{{ form_row(form.contact.firstName) }}
+{{ form_row(form.contact.lastName) }}
+{{ form_row(form.contact.email) }}
+{{ form_row(form.contact.phoneNumber) }}
+
+{{ form_label(form.contact.addresses) }}
+
+<div class="contact-addresses" data-prototype="{{ addressPrototype|e('html_attr') }}">
+    {% for address in form.contact.addresses %}
+        <div>{{ form_row(address) }}</div>
+    {% endfor %}
+</div>
+
+{% do form.contact.setRendered %}
+{{ form_rest(form) }}
+
+<a href="{{ path('organisation_list') }}" class="btn btn-light">Back to list</a>
+<button type="submit" class="btn btn-success float-right">Submit organisation</button>
+{{ form_end(form) }}

--- a/templates/organisations/create.html.twig
+++ b/templates/organisations/create.html.twig
@@ -9,23 +9,9 @@
         </div>
     </div>
 
-    {{ form_start(form) }}
-    <div class="row">
-        <div class="col-12">
-            {{ form_row(form.name) }}
-            {{ form_row(form.website) }}
-            {{ form_row(form.address) }}
-            {{ form_row(form.comment) }}
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-6">
-            <a href="{{ path('organisation_list') }}" class="btn btn-light">Back to list</a>
-        </div>
-        <div class="col-6 text-right">
-            <button type="submit" class="btn btn-success float-right">Add organisation</button>
-        </div>
-    </div>
-    {{ form_end(form) }}
+    {% include 'organisations/_edit_form.html.twig' %}
+{% endblock %}
 
+{% block javascripts %}
+    <script src="{{ asset('build/contact_edit.js') }}"></script>
 {% endblock %}

--- a/templates/organisations/edit.html.twig
+++ b/templates/organisations/edit.html.twig
@@ -9,22 +9,9 @@
         </div>
     </div>
 
-    {{ form_start(form) }}
-    <div class="row">
-        <div class="col-12">
-            {{ form_row(form.name) }}
-            {{ form_row(form.website) }}
-            {{ form_row(form.address) }}
-            {{ form_row(form.comment) }}
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-6">
-            <a href="{{ path('organisation_list') }}" class="btn btn-light">Back to list</a>
-        </div>
-        <div class="col-6">
-            <button type="submit" class="btn btn-success float-right">Edit organisation</button>
-        </div>
-    </div>
-    {{ form_end(form) }}
+    {% include 'organisations/_edit_form.html.twig' %}
+{% endblock %}
+
+{% block javascripts %}
+    <script src="{{ asset('build/contact_edit.js') }}"></script>
 {% endblock %}

--- a/templates/organisations/show.html.twig
+++ b/templates/organisations/show.html.twig
@@ -21,10 +21,29 @@
                     <th>Website</th>
                     <td><a href="{{ organisation.website }}">{{ organisation.website }}</a></td>
                 </tr>
-                <tr>
-                    <th>Address</th>
-                    <td>{{ organisation.address | default('N/A') }}</td>
-                </tr>
+                {% if organisation.contact %}
+                    <tr>
+                        <th>Contact</th>
+                        <td>{{ organisation.contact.firstName }} {{ organisation.contact.lastName }}
+                            {% for address in organisation.contact.addresses %}
+                                 <address>
+                                    {{ address.streetAddress }}<br />
+                                    {{ address.streetAddressComplementary }}<br />
+                                    {{ address.postalCode }} {{ address.city }}
+                                </address>
+                            {% endfor %}
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Email</th>
+                        <td>{{ organisation.contact.email }}</td>
+                    </tr>
+                {% else %}
+                    <tr>
+                        <th>Contact</th>
+                        <td><i>No contact provided.</i></td>
+                    </tr>
+                {% endif %}
                 <tr>
                     <th>Comment</th>
                     <td>{{ organisation.comment | default('N/A') }}</td>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ Encore
     .addEntry('edit_sponsorship_level_benefit', './assets/js/sponsorshipLevelBenefit/edit.js')
     .addEntry("add_slot", "./assets/js/schedule/slot/add_slot.js")
     .addEntry("edit_slot", "./assets/js/schedule/slot/edit_slot.js")
+    .addEntry('contact_edit', './assets/js/contact/edit.js')
 
     /*
      * FEATURE CONFIG


### PR DESCRIPTION
Implements https://github.com/DarkmiraTour/community-event-manager/issues/9

Create entities:
- `Contact` (firstName, lastName, website, Address...)
- `Address` (streetAddress, postalCode, city...)

Then replace `Organisation.address` by a new `Organisation.contact` and `Organisation.contact.addresses`

Update forms templates

### To test it

:warning: Don't forget to run Doctrine migrations

- Go to Organisation
- Create or edit an organisation

You should be able to submit one or many addresses