### PR TITLE
Fix user table name to match with linked entity User

### DIFF
--- a/src/Migrations/Version20181121130537.php
+++ b/src/Migrations/Version20181121130537.php
@@ -10,9 +10,11 @@ use Doctrine\DBAL\Types\Type;
 
 final class Version20181121130537 extends AbstractMigration
 {
+    private const TABLE_NAME = 'app_user';
+
     public function up(Schema $schema): void
     {
-        $table = $schema->createTable('user');
+        $table = $schema->createTable(self::TABLE_NAME);
         $table->addColumn('id', Type::GUID);
         $table->addColumn('email', Type::STRING, ['length' => 320]);
         $table->addColumn('username', Type::STRING, ['length' => 50]);
@@ -25,6 +27,6 @@ final class Version20181121130537 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
-        $schema->dropTable('user');
+        $schema->dropTable(self::TABLE_NAME);
     }
 }


### PR DESCRIPTION
Change user table name in Migration to "app_user" to match with the table name defined in the "User" entity