### PR TITLE
Optimize travis execution time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_script:
     - make install
 
 script:
-    - docker run --rm -v $(pwd):/app phpqa/php-cs-fixer fix --dry-run --diff -vvv
     - docker run --rm -v $(pwd):/app composer vendor/phpmd/phpmd/src/bin/phpmd src text phpmd.xml
     - docker run --rm -v $(pwd):/app composer bin/phpunit
     - docker-compose exec php vendor/bin/behat --format progress --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ before_script:
     - make install
 
 script:
-    - docker run --rm -v $(pwd):/app composer vendor/phpmd/phpmd/src/bin/phpmd src text phpmd.xml
-    - docker run --rm -v $(pwd):/app composer bin/phpunit
+    - docker-compose run composer vendor/phpmd/phpmd/src/bin/phpmd src text phpmd.xml
+    - docker-compose run composer bin/phpunit
     - docker-compose exec php vendor/bin/behat --format progress --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ env:
 php:
     - 7.3
 
+cache:
+    directories:
+        - $HOME/.composer/cache
+
 before_script:
     - sudo rm /usr/local/bin/docker-compose
     - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose


### PR DESCRIPTION
This PR allows travis to cache dependencies in order to improve travis execution time
I removed php-cs-fixer from travis (it is already run by pretty ci)

Fixes #66 