### PR TITLE
Create default bucket with read/write permission

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,21 @@ all: run book
 
 install: .env run initialize book
 
-initialize: run
+initialize: run bucket
 	docker-compose run composer install
 	docker-compose exec php bash -c "php bin/console doctrine:migrations:migrate --no-interaction"
 	docker-compose exec php bash -c "php bin/console doctrine:fixtures:load --no-interaction"
 
 run: .env behat.yml
 	docker-compose up -d
+
+bucket:
+	docker run --network container:`docker-compose ps -q storage` \
+	           --entrypoint="" \
+	           -v `pwd`:/app \
+	           -w /app \
+	           minio/mc \
+	           /bin/sh -c "chmod +x ./docker/minio/create-bucket.sh && ./docker/minio/create-bucket.sh"
 
 test:
 	docker-compose run composer ./vendor/bin/simple-phpunit

--- a/docker/minio/create-bucket.sh
+++ b/docker/minio/create-bucket.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export $(grep -v '^#' .env | xargs)
+
+/usr/bin/mc config host add minio http://storage:9000 ${S3_KEY} ${S3_SECRET};
+/usr/bin/mc rm -r --force minio/events;
+/usr/bin/mc mb minio/events;
+/usr/bin/mc policy download minio/events;


### PR DESCRIPTION
Add a new step in the makefile to create default bucket with the right permissions : `make bucket`
This command is also run during the `make install`

Fixes #74 