### PR TITLE
Add constraints to title length of a slot

### DIFF
--- a/src/Form/SlotType.php
+++ b/src/Form/SlotType.php
@@ -43,6 +43,8 @@ final class SlotType extends AbstractType
                 'attr' => [
                     'class' => 'form-control',
                     'placeholder' => 'Example: PHP in 2019',
+                    'minlength' => "5",
+                    'maxlength'=> "50"
                 ],
             ])
             ->add('start', TimeType::class, [

--- a/src/Form/SlotType.php
+++ b/src/Form/SlotType.php
@@ -43,8 +43,8 @@ final class SlotType extends AbstractType
                 'attr' => [
                     'class' => 'form-control',
                     'placeholder' => 'Example: PHP in 2019',
-                    'minlength' => "5",
-                    'maxlength'=> "50"
+                    'minlength' => '5',
+                    'maxlength' => '50',
                 ],
             ])
             ->add('start', TimeType::class, [


### PR DESCRIPTION
Fix #88 

Adds a minimum and maximum length to the title field when adding a time slot.