### PR TITLE
add title valueobject and add slot construct dependencies

### DIFF
--- a/src/Dto/SlotRequest.php
+++ b/src/Dto/SlotRequest.php
@@ -7,6 +7,7 @@ namespace App\Dto;
 use App\Entity\Slot;
 use App\Entity\SlotType;
 use App\Entity\Space;
+use App\ValueObject\Title;
 use App\Entity\Talk;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -77,7 +78,7 @@ final class SlotRequest
         $slot->setType($this->type);
         $slot->setStart($this->start);
         $slot->setEnd($this->end);
-        $slot->setTitle($this->title);
+        $slot->setTitle(new Title($this->title));
         $slot->setTalk($this->talk);
 
         return $slot;

--- a/src/Entity/Slot.php
+++ b/src/Entity/Slot.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\ValueObject\Title;
 use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\UuidInterface;
 
 /**
  * @ORM\Entity()
@@ -56,6 +58,24 @@ class Slot
      */
     private $space;
 
+    public function __construct(
+        UuidInterface $id,
+        Title $titleObject,
+        int $duration,
+        \DateTimeInterface $start,
+        \DateTimeInterface $end,
+        SlotType $slotType = null,
+        Space $space = null
+    ) {
+        $this->id = $id->toString();
+        $this->title = $titleObject->__toString();
+        $this->duration = $duration;
+        $this->start = $start;
+        $this->end = $end;
+        $this->type = $slotType;
+        $this->space = $space;
+    }
+
     /**
      * @ORM\OneToOne(targetEntity="App\Entity\Talk", cascade={"persist"})
      */
@@ -86,11 +106,11 @@ class Slot
     }
 
     /**
-     * @param string $title
+     * @param Title $title
      */
-    public function setTitle(string $title): void
+    public function setTitle(Title $title): void
     {
-        $this->title = $title;
+        $this->title = $title->__toString();
     }
 
     /**

--- a/src/Exceptions/ValueObject/Title/UnableToCreateTitleException.php
+++ b/src/Exceptions/ValueObject/Title/UnableToCreateTitleException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\ValueObject\Title;
+
+class UnableToCreateTitleException extends \LogicException
+{
+}

--- a/src/Repository/Schedule/SlotRepository.php
+++ b/src/Repository/Schedule/SlotRepository.php
@@ -8,6 +8,7 @@ use App\Dto\SlotRequest;
 use App\Entity\Schedule;
 use App\Entity\Slot;
 use App\Entity\Space;
+use App\ValueObject\Title;
 use App\Entity\Talk;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
@@ -51,14 +52,13 @@ final class SlotRepository implements SlotRepositoryInterface
 
         $duration = ($diff->h * 60) + $diff->i;
 
-        $slot = new Slot();
-        $slot->setId($this->nextIdentity()->toString());
-        $slot->setDuration($duration);
-        $slot->setTitle($slotRequest->title);
-        $slot->setType($slotRequest->type);
-        $slot->setStart($slotRequest->start);
-        $slot->setEnd($slotRequest->end);
-        $slot->setSpace(
+        $slot = new Slot(
+            $this->nextIdentity(),
+            new Title($slotRequest->title),
+            $duration,
+            $slotRequest->start,
+            $slotRequest->end,
+            $slotRequest->type,
             $this->spaceRepository->find($slotRequest->space)
         );
         $slot->setTalk($slotRequest->talk ? $this->talkRepository->find($slotRequest->talk) : null);

--- a/src/ValueObject/Title.php
+++ b/src/ValueObject/Title.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ValueObject;
+
+use App\Exceptions\ValueObject\Title\UnableToCreateTitleException;
+
+final class Title
+{
+    public const MIN_LENGTH = 5;
+    public const MAX_LENGTH = 5;
+    private $title;
+
+    public function __construct(string $title)
+    {
+        if (5 >= strlen($title) && 50 <= strlen($title)) {
+            throw new UnableToCreateTitleException(
+                sprintf('Title length is %d and does not match the requested range from %d to %d.', strlen($title), self::MIN_LENGTH, self::MAX_LENGTH)
+            );
+        }
+        $this->title = $title;
+    }
+
+    public function __toString()
+    {
+        return $this->title;
+    }
+}


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | yes <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | WIP    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | #105    <!-- #-prefixed issue number(s), if any -->

# Description

Title in slot part of the project must be constraints to be between 5 to 50 characters long. But this verification was not implemented into the Slot Entity part.
Therefore I add a Value Object Title that will create a Title object which will take the verification for us.
It adds also the constant "5" and "50" to be reused in other parts of the project, like in the "Add a Slot" form, it will simplify the refactorization if those constraints changes

# Example

```
$slot = new Slot(
//...
$this->title
//...
);
```
Become
```
$slot = new Slot(
//...
new Title($this->title)
//...
);
```
And the construct take a Title object as an argument, when Title is instantiate the length check will be made, and an `UnableToCreateTitleException` will be thrown if case of missmatch