### PR TITLE
Add confirmation page to Delete actions in page

### DIFF
--- a/config/routes/page.yaml
+++ b/config/routes/page.yaml
@@ -28,3 +28,10 @@ page_show:
     methods: [GET]
     requirements:
         id: '%routing.uuid%'
+
+page_confirm_delete:
+    path: /{id}/confirm_delete
+    controller: App\Controller\Page\DeleteConfirmation:handle
+    methods: [GET]
+    requirements:
+        id: '%routing.uuid%'

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -246,6 +246,16 @@ final class FeatureContext extends RawMinkContext
     }
 
     /**
+     * @When /^I click "([^"]*)" link$/
+     */
+    public function iClickLink(string $linkText): void
+    {
+        $link = $this->getSession()->getPage()->findLink($linkText);
+
+        $link->click();
+    }
+
+    /**
      * @AfterStep
      */
     public function takeScreenshotAfterFailedStep(AfterStepScope $scope): void

--- a/features/page.feature
+++ b/features/page.feature
@@ -77,19 +77,21 @@ Feature: Page
     Then I should be redirected on the page listing page
     And I should see "Page 5"
 
-  @javascript
   Scenario: I cancel the delete of page "Page 5"
     Given I am logged in as an admin
     When I am on the page listing page
     And I click "Show" on the row containing "Page 5"
-    And I click "Delete" and cancel popup
-    Then I should see "Page 5"
+    And I click "Delete" link
+    And I should see "Do you wish to confirm \"Page 5\" page deletion?"
+    And I click "Back to list" link
+    Then I should be redirected on the page listing page
+    And I should see "Page 5"
 
-  @javascript
   Scenario: I confirm the delete of page "Page 5"
     Given I am logged in as an admin
     When I am on the page listing page
-    And I click "Show" on the row containing "Page 5"
-    And I click "Delete" and confirm popup
-    Then I should not see "Page 5"
-
+    And I click "Delete" on the row containing "Page 5"
+    And I should see "Do you wish to confirm \"Page 5\" page deletion?"
+    And I press "Delete"
+    Then I should be redirected on the page listing page
+    And I should not see "Page 5"

--- a/src/Controller/Page/DeleteConfirmation.php
+++ b/src/Controller/Page/DeleteConfirmation.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Page;
+
+use App\Repository\Page\PageRepositoryInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment as Twig;
+
+/**
+ * @Security("is_granted('ROLE_ADMIN')")
+ */
+final class DeleteConfirmation
+{
+    private $repository;
+    private $renderer;
+
+    public function __construct(
+        PageRepositoryInterface $repository,
+        Twig $renderer
+    ) {
+        $this->repository = $repository;
+        $this->renderer = $renderer;
+    }
+
+    public function handle(string $id): Response
+    {
+        $page = $this->repository->find($id);
+        if (null === $page) {
+            throw new NotFoundHttpException();
+        }
+
+        return new Response($this->renderer->render('page/confirm_delete.html.twig', [
+            'page' => $page,
+        ]));
+    }
+}

--- a/templates/page/_delete_form.html.twig
+++ b/templates/page/_delete_form.html.twig
@@ -1,5 +1,4 @@
-<form class="d-inline" method="post" action="{{ path('page_delete', {'id': page.id}) }}"
-      onsubmit="return confirm('Are you sure you want to delete this item?');">
+<form class="d-inline" method="post" action="{{ path('page_delete', {'id': page.id}) }}">
     <input type="hidden" name="_method" value="DELETE">
     <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ page.id) }}">
     <button class="btn btn-danger">Delete</button>

--- a/templates/page/confirm_delete.html.twig
+++ b/templates/page/confirm_delete.html.twig
@@ -1,0 +1,28 @@
+{% extends "base.html.twig" %}
+
+{% block title %}Delete page{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col text-center">
+            <h1 class="mb-lg-4 mt-lg-4">Delete page</h1>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-6 offset-3">
+            <div class="card">
+                <div class="card-body text-center">
+                    <h5 class="card-title">Do you wish to confirm "{{ page.title }}" page deletion?</h5>
+                    <div class="row mt-5">
+                        <div class="col-6">
+                            <a href="{{ path('page_index') }}" class="btn btn-light">Back to list</a>
+                        </div>
+                        <div class="col-6">
+                            {{ include('page/_delete_form.html.twig') }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/page/index.html.twig
+++ b/templates/page/index.html.twig
@@ -36,6 +36,10 @@
                                 <a class="btn btn-warning mb-2 mb-md-0" href="{{ path('page_edit', {'id': page.id}) }}">
                                     Edit
                                 </a>
+                                <a href="{{ path('page_confirm_delete', {'id': page.id}) }}"
+                                   class="btn btn-danger mb-2 mb-md-0">
+                                    Delete
+                                </a>
                             {% endif %}
                         </td>
                     </tr>

--- a/templates/page/show.html.twig
+++ b/templates/page/show.html.twig
@@ -37,7 +37,7 @@
         <div class="col-7 text-right">
             {% if is_granted('ROLE_ADMIN') %}
                 <a class="btn btn-warning" href="{{ path('page_edit', {'id': page.id}) }}">Edit</a>
-                {{ include('page/_delete_form.html.twig', { 'page': page }) }}
+                <a href="{{ path('page_confirm_delete', {'id': page.id}) }}" class="btn btn-danger">Delete</a>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
#PR informations

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | yes <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | #107   <!-- #-prefixed issue number(s), if any -->

# Description

Add a confirmation page when we want to delete a page

![image](https://user-images.githubusercontent.com/14071317/54017724-2e9de180-4187-11e9-82d3-8e8ce3026a6f.png)
