### PR TITLE
Add confirmation page to Delete actions in sponsorhip benefit

### DIFF
--- a/config/routes/sponsorshipBenefit.yaml
+++ b/config/routes/sponsorshipBenefit.yaml
@@ -21,3 +21,10 @@ sponsorship_benefit_delete:
     controller: App\Controller\SponsorshipBenefit\Delete::handle
     requirements:
         id: '%routing.uuid%'
+
+sponsorship_benefit_confirm_delete:
+    path: /{id}/confirm_delete
+    controller: App\Controller\SponsorshipBenefit\DeleteConfirmation:handle
+    methods: [GET]
+    requirements:
+        id: '%routing.uuid%'

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -246,6 +246,15 @@ final class FeatureContext extends RawMinkContext
     }
 
     /**
+     * @When /^I click "([^"]*)" link$/
+     */
+    public function iClickLink(string $linkText): void
+    {
+        $link = $this->getSession()->getPage()->findLink($linkText);
+        $link->click();
+    }
+
+    /**
      * @AfterStep
      */
     public function takeScreenshotAfterFailedStep(AfterStepScope $scope): void

--- a/features/sponsorshipBenefit.feature
+++ b/features/sponsorshipBenefit.feature
@@ -34,16 +34,20 @@ Feature: Sponsorship Benefit
     Then I should be redirected on the sponsorship benefit listing page
     And I should see "Benefit 12"
 
-  @javascript
   Scenario: I cancel the delete of sponsorship benefit "Benefit 12"
     Given I am logged in as an admin
     When I am on the sponsorship benefit listing page
-    And I press "Delete" on the row containing "Benefit 12" and cancel popup
-    Then I should see "Benefit 12"
+    And I click "Delete" on the row containing "Benefit 12"
+    And I should see "Do you wish to confirm \"Benefit 12\" sponsorship benefit deletion?"
+    And I click "Back to list" link
+    Then I should be redirected on the sponsorship benefit listing page
+    And I should see "Benefit 12"
 
-  @javascript
   Scenario: I confirm the delete of sponsorship benefit "Benefit 12"
     Given I am logged in as an admin
     When I am on the sponsorship benefit listing page
-    And I press "Delete" on the row containing "Benefit 12" and confirm popup
-    Then I should not see "Benefit 12"
+    And I click "Delete" on the row containing "Benefit 12"
+    And I should see "Do you wish to confirm \"Benefit 12\" sponsorship benefit deletion?"
+    And I press "Delete"
+    Then I should be redirected on the sponsorship benefit listing page
+    And I should not see "Benefit 12"

--- a/src/Controller/SponsorshipBenefit/DeleteConfirmation.php
+++ b/src/Controller/SponsorshipBenefit/DeleteConfirmation.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\SponsorshipBenefit;
+
+use App\Repository\SponsorshipBenefit\SponsorshipBenefitRepositoryInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment as Twig;
+
+/**
+ * @Security("is_granted('ROLE_ADMIN')")
+ */
+final class DeleteConfirmation
+{
+    private $repository;
+    private $renderer;
+
+    public function __construct(
+        SponsorshipBenefitRepositoryInterface $repository,
+        Twig $renderer
+    ) {
+        $this->repository = $repository;
+        $this->renderer = $renderer;
+    }
+
+    public function handle(string $id): Response
+    {
+        $sponsorshipBenefit = $this->repository->find($id);
+        if (null === $sponsorshipBenefit) {
+            throw new NotFoundHttpException();
+        }
+
+        return new Response($this->renderer->render('sponsorshipBenefit/confirm_delete.html.twig', [
+            'sponsorshipBenefit' => $sponsorshipBenefit,
+        ]));
+    }
+}

--- a/templates/sponsorshipBenefit/_delete_form.html.twig
+++ b/templates/sponsorshipBenefit/_delete_form.html.twig
@@ -1,6 +1,5 @@
-<form class="d-inline" method="post" action="{{ path('sponsorship_benefit_delete', {'id': benefit.id}) }}"
-      onsubmit="return confirm('Are you sure you want to delete this item?');">
+<form class="d-inline" method="post" action="{{ path('sponsorship_benefit_delete', {'id': sponsorshipBenefit.id}) }}">
     <input type="hidden" name="_method" value="DELETE">
-    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ benefit.id) }}">
+    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ sponsorshipBenefit.id) }}">
     <button class="btn btn-danger" type="submit">Delete</button>
 </form>

--- a/templates/sponsorshipBenefit/confirm_delete.html.twig
+++ b/templates/sponsorshipBenefit/confirm_delete.html.twig
@@ -1,0 +1,28 @@
+{% extends "base.html.twig" %}
+
+{% block title %}Delete sponsorship benefit{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col text-center">
+            <h1 class="mb-lg-4 mt-lg-4">Delete sponsorship benefit</h1>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-6 offset-3">
+            <div class="card">
+                <div class="card-body text-center">
+                    <h5 class="card-title">Do you wish to confirm "{{ sponsorshipBenefit.label }}" sponsorship benefit deletion?</h5>
+                    <div class="row mt-5">
+                        <div class="col-6">
+                            <a href="{{ path('sponsorship_benefit_index') }}" class="btn btn-light">Back to list</a>
+                        </div>
+                        <div class="col-6">
+                            {{ include('sponsorshipBenefit/_delete_form.html.twig') }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/sponsorshipBenefit/index.html.twig
+++ b/templates/sponsorshipBenefit/index.html.twig
@@ -33,7 +33,8 @@
                             <td class="text-right">
                                 <a class="btn btn-warning"
                                    href="{{ path('sponsorship_benefit_edit', {'id': benefit.id}) }}">Edit</a>
-                                {{ include('sponsorshipBenefit/_delete_form.html.twig', { 'benefit': benefit }) }}
+                                <a class="btn btn-danger"
+                                   href="{{ path('sponsorship_benefit_confirm_delete', {'id': benefit.id}) }}">Delete</a>
                             </td>
                         {% endif %}
                     </tr>


### PR DESCRIPTION
#PR informations

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | yes <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | #107   <!-- #-prefixed issue number(s), if any -->

# Description

Add a confirmation page when we want to delete a sponsorship benefit

![image](https://user-images.githubusercontent.com/14071317/54026475-31f09780-419e-11e9-9f8c-be8ab54d0c91.png)
