### PR TITLE
Add confirmation page to Delete actions in sponsorhip level

### DIFF
--- a/config/routes/sponsorshipLevel.yaml
+++ b/config/routes/sponsorshipLevel.yaml
@@ -21,3 +21,10 @@ sponsorship_level_delete:
     controller: App\Controller\SponsorshipLevel\Delete::handle
     requirements:
         id: '%routing.uuid%'
+
+sponsorship_level_confirm_delete:
+    path: /{id}/confirm_delete
+    controller: App\Controller\SponsorshipLevel\DeleteConfirmation:handle
+    methods: [GET]
+    requirements:
+        id: '%routing.uuid%'

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -246,6 +246,15 @@ final class FeatureContext extends RawMinkContext
     }
 
     /**
+     * @When /^I click "([^"]*)" link$/
+     */
+    public function iClickLink(string $linkText): void
+    {
+        $link = $this->getSession()->getPage()->findLink($linkText);
+        $link->click();
+    }
+
+    /**
      * @AfterStep
      */
     public function takeScreenshotAfterFailedStep(AfterStepScope $scope): void

--- a/features/sponsorshipLevel.feature
+++ b/features/sponsorshipLevel.feature
@@ -53,16 +53,20 @@ Feature: Sponsorship Level
     Then I should be redirected on the sponsorship level listing page
     And I should see "Level 10"
 
-  @javascript
   Scenario: I cancel the delete of sponsorship level "Level 10"
     Given I am logged in as an admin
     When I am on the sponsorship level listing page
-    And I press "Delete" on the row containing "Level 10" and cancel popup
-    Then I should see "Level 10"
+    And I click "Delete" on the row containing "Level 10"
+    And I should see "Do you wish to confirm \"Level 10\" sponsorship level deletion?"
+    And I click "Back to list" link
+    Then I should be redirected on the sponsorship level listing page
+    And I should see "Level 10"
 
-  @javascript
   Scenario: I confirm the delete of sponsorship level "Level 10"
     Given I am logged in as an admin
     When I am on the sponsorship level listing page
-    And I press "Delete" on the row containing "Level 10" and confirm popup
-    Then I should not see "Level 10"
+    And I click "Delete" on the row containing "Level 10"
+    And I should see "Do you wish to confirm \"Level 10\" sponsorship level deletion?"
+    And I press "Delete"
+    Then I should be redirected on the sponsorship level listing page
+    And I should not see "Level 10"

--- a/src/Controller/SponsorshipLevel/DeleteConfirmation.php
+++ b/src/Controller/SponsorshipLevel/DeleteConfirmation.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\SponsorshipLevel;
+
+use App\Repository\SponsorshipLevel\SponsorshipLevelRepositoryInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment as Twig;
+
+/**
+ * @Security("is_granted('ROLE_ADMIN')")
+ */
+final class DeleteConfirmation
+{
+    private $repository;
+    private $renderer;
+
+    public function __construct(
+        SponsorshipLevelRepositoryInterface $repository,
+        Twig $renderer
+    ) {
+        $this->repository = $repository;
+        $this->renderer = $renderer;
+    }
+
+    public function handle(string $id): Response
+    {
+        $sponsorshipLevel = $this->repository->find($id);
+        if (null === $sponsorshipLevel) {
+            throw new NotFoundHttpException();
+        }
+
+        return new Response($this->renderer->render('sponsorshipLevel/confirm_delete.html.twig', [
+            'sponsorshipLevel' => $sponsorshipLevel,
+        ]));
+    }
+}

--- a/templates/sponsorshipLevel/_delete_form.html.twig
+++ b/templates/sponsorshipLevel/_delete_form.html.twig
@@ -1,7 +1,5 @@
-<form class="d-inline" method="post"
-      action="{{ path('sponsorship_level_delete', {'id': level.id}) }}"
-      onsubmit="return confirm('Are you sure you want to delete this item?');">
+<form class="d-inline" method="post" action="{{ path('sponsorship_level_delete', {'id': sponsorshipLevel.id}) }}">
     <input type="hidden" name="_method" value="DELETE">
-    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ level.id) }}">
+    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ sponsorshipLevel.id) }}">
     <button class="btn btn-danger">Delete</button>
 </form>

--- a/templates/sponsorshipLevel/confirm_delete.html.twig
+++ b/templates/sponsorshipLevel/confirm_delete.html.twig
@@ -1,0 +1,28 @@
+{% extends "base.html.twig" %}
+
+{% block title %}Delete sponsorship level{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col text-center">
+            <h1 class="mb-lg-4 mt-lg-4">Delete sponsorship level</h1>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-6 offset-3">
+            <div class="card">
+                <div class="card-body text-center">
+                    <h5 class="card-title">Do you wish to confirm "{{ sponsorshipLevel.label }}" sponsorship level deletion?</h5>
+                    <div class="row mt-5">
+                        <div class="col-6">
+                            <a href="{{ path('sponsorship_level_index') }}" class="btn btn-light">Back to list</a>
+                        </div>
+                        <div class="col-6">
+                            {{ include('sponsorshipLevel/_delete_form.html.twig') }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/sponsorshipLevel/index.html.twig
+++ b/templates/sponsorshipLevel/index.html.twig
@@ -35,7 +35,10 @@
                             <td class="text-right">
                                 <a class="btn btn-warning mb-2 mb-md-0"
                                    href="{{ path('sponsorship_level_edit', {'id': level.id}) }}">Edit</a>
-                                {{ include('sponsorshipLevel/_delete_form.html.twig', { 'level': level }) }}
+                                <a class="btn btn-danger"
+                                   href="{{ path('sponsorship_level_confirm_delete', {'id': level.id}) }}">
+                                    Delete
+                                </a>
                             </td>
                         {% endif %}
                     </tr>


### PR DESCRIPTION
#PR informations

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | yes <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | #107   <!-- #-prefixed issue number(s), if any -->

# Description

Add a confirmation page when we want to delete a sponsorship level

![image](https://user-images.githubusercontent.com/14071317/54027344-821d2900-41a1-11e9-878c-7b3a87e31ce4.png)
