### PR TITLE
Add confirmation page to Delete actions in talk

### DIFF
--- a/config/routes/talks.yaml
+++ b/config/routes/talks.yaml
@@ -28,3 +28,10 @@ talk_delete:
     controller: App\Controller\Talk\Delete::handle
     requirements:
         id: '%routing.uuid%'
+
+talk_confirm_delete:
+    path: /{id}/confirm_delete
+    controller: App\Controller\Talk\DeleteConfirmation:handle
+    methods: [GET]
+    requirements:
+        id: '%routing.uuid%'

--- a/src/Controller/Talk/DeleteConfirmation.php
+++ b/src/Controller/Talk/DeleteConfirmation.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Talk;
+
+use App\Repository\TalkRepositoryInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment as Twig;
+
+/**
+ * @Security("is_granted('ROLE_ADMIN')")
+ */
+final class DeleteConfirmation
+{
+    private $repository;
+    private $renderer;
+
+    public function __construct(
+        TalkRepositoryInterface $repository,
+        Twig $renderer
+    ) {
+        $this->repository = $repository;
+        $this->renderer = $renderer;
+    }
+
+    public function handle(string $id): Response
+    {
+        $talk = $this->repository->find($id);
+        if (null === $talk) {
+            throw new NotFoundHttpException();
+        }
+
+        return new Response($this->renderer->render('talks/confirm_delete.html.twig', [
+            'talk' => $talk,
+        ]));
+    }
+}

--- a/templates/talks/_delete_form.html.twig
+++ b/templates/talks/_delete_form.html.twig
@@ -1,6 +1,4 @@
-<form method="post" action="{{ path('talk_delete', {'id': talk.id}) }}"
-      onsubmit="return confirm('Are you sure you want to delete this talk?');"
-      class="d-inline-block">
+<form method="post" action="{{ path('talk_delete', {'id': talk.id}) }}" class="d-inline-block">
     <input type="hidden" name="_method" value="DELETE">
     <input type="hidden" name="_token" value="{{ csrf_token('talk-' ~ talk.id) }}">
     <button type="submit" class="btn btn-danger">Delete</button>

--- a/templates/talks/confirm_delete.html.twig
+++ b/templates/talks/confirm_delete.html.twig
@@ -1,0 +1,28 @@
+{% extends "base.html.twig" %}
+
+{% block title %}Delete talk{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col text-center">
+            <h1 class="mb-lg-4 mt-lg-4">Delete talk</h1>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-6 offset-3">
+            <div class="card">
+                <div class="card-body text-center">
+                    <h5 class="card-title">Do you wish to confirm "{{ talk.title }}" talk deletion?</h5>
+                    <div class="row mt-5">
+                        <div class="col-6">
+                            <a href="{{ path('talk_index') }}" class="btn btn-light">Back to list</a>
+                        </div>
+                        <div class="col-6">
+                            {{ include('talks/_delete_form.html.twig') }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/talks/index.html.twig
+++ b/templates/talks/index.html.twig
@@ -38,6 +38,10 @@
                                    class="btn btn-warning mb-2 mb-md-0">
                                     Edit
                                 </a>
+                                <a href="{{ path('talk_confirm_delete', {'id': talk.id}) }}"
+                                   class="btn btn-danger mb-2 mb-md-0">
+                                    Delete
+                                </a>
                             {% endif %}
                         </td>
                     </tr>

--- a/templates/talks/show.html.twig
+++ b/templates/talks/show.html.twig
@@ -39,7 +39,7 @@
         <div class="col-7 text-right">
             {% if is_granted('ROLE_ADMIN') %}
                 <a href="{{ path('talk_edit', {'id': talk.id}) }}" class="btn btn-warning">Edit</a>
-                {{ include('talks/_delete_form.html.twig', {'talk': talk}) }}
+                <a href="{{ path('talk_confirm_delete', {'id': talk.id}) }}" class="btn btn-danger">Delete</a>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
#PR informations

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | yes <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | #107   <!-- #-prefixed issue number(s), if any -->

# Description

Add a confirmation page when we want to delete a talk

![image](https://user-images.githubusercontent.com/14071317/54030508-1e4c2d80-41ac-11e9-97d8-cb8847c70622.png)
