### PR TITLE
fixes #112 - add Behat test suite into make test command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ bucket:
 
 test:
 	docker-compose run composer ./vendor/bin/simple-phpunit
+	docker-compose run php vendor/bin/behat
 
 logs:
 	docker-compose logs -ft


### PR DESCRIPTION
# PR informations

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | yes <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | #112   <!-- #-prefixed issue number(s), if any -->

# Description

When launching the `make test` command like it's described in the README file, it run the composer docker container to launch simple-phpunit.
As we also have a Behat test suite, it's important this command launch Behat too.
Therefore this feature add the start of the php container and launch Behat.
