### PR TITLE
Remove file_put_contents call

### DIFF
--- a/src/Controller/GeneratePdf.php
+++ b/src/Controller/GeneratePdf.php
@@ -8,7 +8,6 @@ use App\Repository\Page\PageManagerInterface;
 use App\Repository\SpecialBenefit\SpecialBenefitManagerInterface;
 use App\Repository\SponsorshipLevel\SponsorshipLevelManagerInterface;
 use App\Repository\SponsorshipLevelBenefit\SponsorshipLevelBenefitManagerInterface;
-use App\Service\FileUploaderInterface;
 use App\Service\FormatSponsorshipLevelBenefit;
 use App\Service\PdfCreatorInterface;
 use Twig\Environment as Twig;
@@ -23,7 +22,6 @@ final class GeneratePdf
     private $sponsorshipLevelManager;
     private $pageManager;
     private $specialBenefitManager;
-    private $fileUploader;
 
     public function __construct(
         Twig $renderer,
@@ -32,8 +30,7 @@ final class GeneratePdf
         FormatSponsorshipLevelBenefit $formatSponsorshipLevelBenefit,
         SponsorshipLevelManagerInterface $sponsorshipLevelManager,
         PageManagerInterface $pageManager,
-        SpecialBenefitManagerInterface $specialBenefitManager,
-        FileUploaderInterface $fileUploader
+        SpecialBenefitManagerInterface $specialBenefitManager
     ) {
         $this->renderer = $renderer;
         $this->pdfCreator = $pdfCreator;
@@ -42,15 +39,11 @@ final class GeneratePdf
         $this->sponsorshipLevelManager = $sponsorshipLevelManager;
         $this->pageManager = $pageManager;
         $this->specialBenefitManager = $specialBenefitManager;
-        $this->fileUploader = $fileUploader;
     }
 
     public function handle(): Response
     {
         $pages = $this->pageManager->findAll();
-        foreach ($pages as $page) {
-            $this->fileUploader->makeTempFile($page->getBackground());
-        }
 
         $template = $this->renderer->render('pdf/index.html.twig', [
             'pages' => $pages,

--- a/src/Service/FileUploader.php
+++ b/src/Service/FileUploader.php
@@ -31,9 +31,8 @@ final class FileUploader implements FileUploaderInterface
         return $this->filesystem->read($fileName);
     }
 
-    public function makeTempFile(string $fileName): void
+    public function getOriginalFileExtension(string $file): string
     {
-        $content = $this->get($fileName);
-        file_put_contents(sys_get_temp_dir().'/'.$fileName, $content);
+        return substr(strrchr($file, '.'), 1);
     }
 }

--- a/src/Service/FileUploaderInterface.php
+++ b/src/Service/FileUploaderInterface.php
@@ -12,5 +12,5 @@ interface FileUploaderInterface
 
     public function get(string $fileName): string;
 
-    public function makeTempFile(string $fileName): void;
+    public function getOriginalFileExtension(string $file): string;
 }

--- a/src/Twig/ImageToBase64Extension.php
+++ b/src/Twig/ImageToBase64Extension.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class ImageToBase64Extension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('base64_image_from_storage', [
+                ImageToBase64Runtime::class,
+                'imageToBase64',
+            ]),
+        ];
+    }
+}

--- a/src/Twig/ImageToBase64Runtime.php
+++ b/src/Twig/ImageToBase64Runtime.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig;
+
+use Twig\Extension\RuntimeExtensionInterface;
+use App\Service\FileUploaderInterface;
+
+final class ImageToBase64Runtime implements RuntimeExtensionInterface
+{
+    private $fileUploader;
+
+    public function __construct(FileUploaderInterface $fileUploader)
+    {
+        $this->fileUploader = $fileUploader;
+    }
+
+    public function imageToBase64(string $data): string
+    {
+        $type = $this->fileUploader->getOriginalFileExtension($data);
+        $image = $this->fileUploader->get($data);
+        $imageBase64 = base64_encode($image);
+
+        return sprintf('data:image/%s;base64,%s', $type, $imageBase64);
+    }
+}

--- a/templates/pdf/pages.html.twig
+++ b/templates/pdf/pages.html.twig
@@ -1,7 +1,7 @@
 {% for page in pages %}
     <div style="position: absolute; left: 50%; margin-left: -420px; top: 15%; width: 841px; height: 595px; overflow: hidden;">
         <div style="position:absolute; left: 0px; top: 0px;">
-            <img src="/tmp/{{ page.background }}" width="60%"></div>
+            <img src="{{ base64_image_from_storage(page.background) }}" width="60%"></div>
         <div style="width: 400px; height: 400px; margin-left: 40%; padding-left: 10px; padding-top: 80px; padding-bottom: 25px; float: right; background-color: white; text-align: justify; border-left: 5px solid #6AA84F;">
             <h3 style="color: #6AA84F; margin-bottom: 0px;">{{ page.title }}</h3>
             <p style="font-size: 14pt;">{{ page.content|nl2br }}</p>


### PR DESCRIPTION
#PR informations

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | yes <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | #84    <!-- #-prefixed issue number(s), if any -->

# Description
Remove `file_put_contents` call to avoid  errors  because then the view (for the pdf) is using /tmp/ paths.
related issue #131 for data uri and base64 images