### PR TITLE
Fixes 103 - add multiple events management + link schedule to event

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -13,6 +13,7 @@ default:
         - ScheduleContext
         - InterviewQuestionContext
         - SendInterviewContext
+        - EventContext
   extensions:
     Behat\Symfony2Extension:
       kernel:

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -56,3 +56,7 @@ sponsorships_pdf:
 interview_question:
     resource: routes/interviewQuestion.yaml
     prefix: interview-question
+
+events:
+    resource: routes/events.yaml
+    prefix: events

--- a/config/routes/events.yaml
+++ b/config/routes/events.yaml
@@ -1,0 +1,49 @@
+event_index:
+    path: /
+    methods: [GET]
+    controller: App\Controller\Event\Index::handle
+
+event_select:
+    path: /select/{id}
+    methods: [GET]
+    controller: App\Controller\Event\Select::handle
+    requirements:
+        id: '%routing.uuid%'
+
+event_unselect:
+    path: /unselect
+    methods: [GET]
+    controller: App\Controller\Event\Unselect::handle
+
+event_create:
+    path: /create
+    methods: [GET, POST]
+    controller: App\Controller\Event\Create::handle
+
+event_show:
+    path: /{id}
+    methods: [GET]
+    controller: App\Controller\Event\Show::handle
+    requirements:
+        id: '%routing.uuid%'
+
+event_edit:
+    path: /{id}/edit
+    methods: [GET, PUT]
+    controller: App\Controller\Event\Edit::handle
+    requirements:
+        id: '%routing.uuid%'
+
+event_delete:
+    path: /{id}/delete
+    methods: [DELETE]
+    controller: App\Controller\Event\Delete::handle
+    requirements:
+        id: '%routing.uuid%'
+
+event_confirm_delete:
+    path: /{id}/confirm_delete
+    controller: App\Controller\Event\DeleteConfirmation:handle
+    methods: [GET]
+    requirements:
+        id: '%routing.uuid%'

--- a/features/bootstrap/EventContext.php
+++ b/features/bootstrap/EventContext.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\MinkExtension\Context\RawMinkContext;
+
+final class EventContext extends RawMinkContext
+{
+    /**
+     * @When /^I am on the event listing page$/
+     */
+    public function iAmOnTheEventListingPage(): void
+    {
+        $this->visitPath('/');
+    }
+
+    /**
+     * @When /^I am on the event creation page$/
+     */
+    public function iAmOnTheEventCreationPage(): void
+    {
+        $this->visitPath('events/create');
+    }
+
+    /**
+     * @Then /^I should be redirected on the event listing page$/
+     */
+    public function iShouldBeRedirectedOnTheEventListingPage(): void
+    {
+        $this->assertSession()->addressEquals($this->locatePath('/'));
+    }
+
+    /**
+     * @When /^I fill the event "([^"]*)" field with "([^"]*)"$/
+     */
+    public function iFillTheEventFieldWith(string $field, string $value): void
+    {
+        $field = $this->fixStepArgument('event['.$field.']');
+        $value = $this->fixStepArgument($value);
+        $this->getSession()->getPage()->fillField($field, $value);
+    }
+
+    /**
+     * @When /^I fill the event "([^"]*)" field with date "([^"]*)"$/
+     */
+    public function iFillTheEventDateFieldWith(string $field, string $value): void
+    {
+        $field = $this->fixStepArgument('event['.$field.']');
+        $this->getSession()->getPage()->fillField($field, new \DateTime($value));
+    }
+
+    /**
+     * @When /^I fill the event "([^"]*)" "([^"]*)" date field with "([^"]*)"$/
+     */
+    public function iFillTheEventDatePeriodFieldWith(string $field, string $period, string $value): void
+    {
+        $field = $this->fixStepArgument("event[$field][$period]");
+        $this->getSession()->getPage()->fillField($field, $value);
+    }
+
+    /**
+     * @When /^I fill the event "([^"]*)" "([^"]*)" address field with "([^"]*)"$/
+     */
+    public function iFillTheEventAddressFieldWith(string $field, string $period, string $value): void
+    {
+        $field = $this->fixStepArgument("event[$field][$period]");
+        $this->getSession()->getPage()->fillField($field, $value);
+    }
+
+    private function fixStepArgument(string $argument): string
+    {
+        return str_replace('\\"', '"', $argument);
+    }
+}

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -57,6 +57,22 @@ final class FeatureContext extends RawMinkContext
     }
 
     /**
+     * @Given I am logged in as a user
+     */
+    public function iAmLoggedInAsAUser(): void
+    {
+        $em = $this->kernel->getContainer()->get('doctrine')->getManager();
+        $this->currentUser = $em->getRepository(User::class)->findOneBy([
+            'email' => 'user@test.com',
+        ]);
+
+        $this->visitPath('/login');
+        $this->getSession()->getPage()->fillField('login[email]', 'user@test.com');
+        $this->getSession()->getPage()->fillField('login[password]', 'userpass');
+        $this->getSession()->getPage()->pressButton('Sign in');
+    }
+
+    /**
      * @When /^I click "([^"]*)" on the row containing "([^"]*)"$/
      */
     public function iClickOnOnTheRowContaining(string $linkName, string $rowText): void

--- a/features/event.feature
+++ b/features/event.feature
@@ -1,0 +1,146 @@
+Feature: Event Selection
+  In order to test CRUD on Event
+  As an admin
+  I need to be able to list all events and fill forms
+
+  Scenario: I don't add an event and go back to home
+    Given I am logged in as an admin
+    When I am on the event creation page
+    And I fill the event "name" field with "DarkmiraTour 2021"
+    And I fill the event "description" field with "For the PHP community In Brazil"
+    And I fill the event "address" "name" address field with "Fortaleza"
+    And I fill the event "address" "streetAddress" address field with "6-7 Fortaleza"
+    And I fill the event "address" "streetAddressComplementary" address field with ""
+    And I fill the event "address" "postalCode" address field with "1234"
+    And I fill the event "address" "city" address field with "Brazil-city"
+    And I fill the event "startAt" "day" date field with "1"
+    And I fill the event "startAt" "month" date field with "2"
+    And I fill the event "startAt" "year" date field with "2020"
+    And I fill the event "endAt" "day" date field with "4"
+    And I fill the event "endAt" "month" date field with "2"
+    And I fill the event "endAt" "year" date field with "2020"
+    And I click "Back to home" link
+    Then I should be redirected on the event listing page
+    And I should see "Events management"
+    And I should not see "DarkmiraTour 2021"
+
+  Scenario: I add an event
+    Given I am logged in as an admin
+    When I am on the event creation page
+    And I fill the event "name" field with "DarkmiraTour 2020"
+    And I fill the event "description" field with "For the PHP community In Brazil"
+    And I fill the event "address" "name" address field with "Fortaleza"
+    And I fill the event "address" "streetAddress" address field with "6-7 Fortaleza"
+    And I fill the event "address" "streetAddressComplementary" address field with ""
+    And I fill the event "address" "postalCode" address field with "1234"
+    And I fill the event "address" "city" address field with "Brazil-city"
+    And I fill the event "startAt" "day" date field with "1"
+    And I fill the event "startAt" "month" date field with "2"
+    And I fill the event "startAt" "year" date field with "2020"
+    And I fill the event "endAt" "day" date field with "4"
+    And I fill the event "endAt" "month" date field with "2"
+    And I fill the event "endAt" "year" date field with "2020"
+    And I press "Create Event"
+    Then I should be redirected on the event listing page
+    And I should see "Events management"
+    And I should see "DarkmiraTour 2020"
+
+  Scenario: I select the event "DarkmiraTour 2020"
+    Given I am logged in as a user
+    When I am on the event listing page
+    And I should see "Select DarkmiraTour 2020"
+    And I click "Select DarkmiraTour 2020" link
+    Then I should see "You have selected the DarkmiraTour 2020 event, you can now start to manage it."
+    And I should see "DarkmiraTour 2020 management in progress"
+    
+  Scenario: I unselect the event "DarkmiraTour 2020" after selecting it
+    Given I am logged in as a user
+    When I am on the event listing page
+    And I should see "Select DarkmiraTour 2020"
+    And I click "Select DarkmiraTour 2020" link
+    Then I should see "You have selected the DarkmiraTour 2020 event, you can now start to manage it."
+    And I should see "DarkmiraTour 2020 management in progress"
+    And I click "DarkmiraTour 2020 management in progress" link
+    Then I should be redirected on the event listing page
+    And I should see "Finish management on DarkmiraTour 2020"
+    And I click "Finish management on DarkmiraTour 2020" link
+    Then I should see "Select DarkmiraTour 2020"
+    
+  Scenario: I don't fill all data needed when I add an event
+    Given I am logged in as an admin
+    When I am on the event creation page
+    And I press "Create Event"
+    Then I should see "This value should not be blank."
+
+  Scenario: I fill a passed date on the event creation page
+    Given I am logged in as an admin
+    When I am on the event creation page
+    And I fill the event "name" field with "DarkmiraTour 2021"
+    And I fill the event "description" field with "For the PHP community In Brazil"
+    And I fill the event "address" "name" address field with "Fortaleza"
+    And I fill the event "address" "streetAddress" address field with "6-7 Fortaleza"
+    And I fill the event "address" "streetAddressComplementary" address field with ""
+    And I fill the event "address" "postalCode" address field with "1234"
+    And I fill the event "address" "city" address field with "Brazil-city"
+    And I fill the event "startAt" "day" date field with "1"
+    And I fill the event "startAt" "month" date field with "1"
+    And I fill the event "startAt" "year" date field with "2014"
+    And I fill the event "endAt" "day" date field with "4"
+    And I fill the event "endAt" "month" date field with "2"
+    And I fill the event "endAt" "year" date field with "2014"
+    And I press "Create Event"
+    Then I should see "The date \"Jan 01 2014\" cannot be set in the past."
+
+  Scenario: I fill a start date more recent than the end date on the event creation page
+    Given I am logged in as an admin
+    When I am on the event creation page
+    And I fill the event "name" field with "DarkmiraTour 2021"
+    And I fill the event "description" field with "For the PHP community In Brazil"
+    And I fill the event "address" "name" address field with "Fortaleza"
+    And I fill the event "address" "streetAddress" address field with "6-7 Fortaleza"
+    And I fill the event "address" "streetAddressComplementary" address field with ""
+    And I fill the event "address" "postalCode" address field with "1234"
+    And I fill the event "address" "city" address field with "Brazil-city"
+    And I fill the event "startAt" "day" date field with "10"
+    And I fill the event "startAt" "month" date field with "1"
+    And I fill the event "startAt" "year" date field with "2020"
+    And I fill the event "endAt" "day" date field with "1"
+    And I fill the event "endAt" "month" date field with "1"
+    And I fill the event "endAt" "year" date field with "2020"
+    And I press "Create Event"
+    Then I should see "Start date \"Jan 10 2020\" cannot be higher than end date \"Jan 01 2020\""
+
+  Scenario: I don't fill all data needed when i edit a event "DarkmiraTour 2020"
+    Given I am logged in as an admin
+    When I am on the event listing page
+    And I click "Edit" on the row containing "DarkmiraTour 2020"
+    And I fill the event "name" field with ""
+    And I press "Save changes"
+    Then I should see "This value should not be blank."
+
+  Scenario: I edit the event "DarkmiraTour 2020"
+    Given I am logged in as an admin
+    When I am on the event listing page
+    And I click "Edit" on the row containing "DarkmiraTour 2020"
+    And I fill the event "name" field with "Darkmira-Tour 2020"
+    And I press "Save changes"
+    Then I should see "Darkmira-Tour 2020"
+    And I should see "Event"
+
+  Scenario: I cancel the delete of event "Darkmira-Tour 2020"
+    Given I am logged in as an admin
+    When I am on the event listing page
+    And I click "Delete" on the row containing "Darkmira-Tour 2020"
+    And I should see "Do you wish to confirm \"Darkmira-Tour 2020\" event deletion?"
+    And I click "Back to list" link
+    Then I should be redirected on the event listing page
+    And I should see "Darkmira-Tour 2020"
+
+  Scenario: I confirm the delete of event "Darkmira-Tour 2020"
+    Given I am logged in as an admin
+    When I am on the event listing page
+    And I click "Delete" on the row containing "Darkmira-Tour 2020"
+    And I should see "Do you wish to confirm \"Darkmira-Tour 2020\" event deletion?"
+    And I press "Delete"
+    Then I should be redirected on the event listing page
+    And I should not see "Darkmira-Tour 2020"

--- a/src/Controller/Event/Create.php
+++ b/src/Controller/Event/Create.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Event;
+
+use App\Dto\EventRequest;
+use App\Form\EventType;
+use App\Repository\Event\EventRepository;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Twig\Environment as Twig;
+
+/**
+ * @Security("is_granted('ROLE_ADMIN')")
+ */
+final class Create
+{
+    private $renderer;
+    private $formFactory;
+    private $eventRepository;
+    private $router;
+
+    public function __construct(
+        Twig $renderer,
+        FormFactoryInterface $formFactory,
+        EventRepository $eventRepository,
+        RouterInterface $router
+    ) {
+        $this->renderer = $renderer;
+        $this->formFactory = $formFactory;
+        $this->eventRepository = $eventRepository;
+        $this->router = $router;
+    }
+
+    public function handle(Request $request): Response
+    {
+        $eventRequest = new EventRequest();
+        $form = $this->formFactory->create(EventType::class, $eventRequest);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $event = $this->eventRepository->createFromRequest($eventRequest);
+            $this->eventRepository->save($event);
+
+            return new RedirectResponse($this->router->generate('index'));
+        }
+
+        return new Response($this->renderer->render(
+            'event/create.html.twig', [
+                'form' => $form->createView(),
+            ])
+        );
+    }
+}

--- a/src/Controller/Event/Delete.php
+++ b/src/Controller/Event/Delete.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Event;
+
+use App\Repository\Event\EventRepositoryInterface;
+use Ramsey\Uuid\Uuid;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Twig\Environment as Twig;
+
+final class Delete
+{
+    private $renderer;
+    private $repository;
+    private $csrfTokenManager;
+    private $router;
+
+    public function __construct(
+        Twig $renderer,
+        EventRepositoryInterface $repository,
+        CsrfTokenManagerInterface $csrfTokenManager,
+        RouterInterface $router
+    ) {
+        $this->renderer = $renderer;
+        $this->repository = $repository;
+        $this->csrfTokenManager = $csrfTokenManager;
+        $this->router = $router;
+    }
+
+    /**
+     * @Security("is_granted('ROLE_ADMIN')")
+     */
+    public function handle(Request $request): Response
+    {
+        $id = Uuid::fromString($request->attributes->get('id'))->toString();
+
+        if (null === ($event = $this->repository->findById($id))) {
+            throw new NotFoundHttpException(sprintf('The event could not be found this this id %s', $id));
+        }
+
+        $token = new CsrfToken('delete'.$event->getId(), $request->request->get('_token'));
+        if ($this->csrfTokenManager->isTokenValid($token)) {
+            $this->repository->remove($event);
+        }
+
+        return new RedirectResponse($this->router->generate('index'));
+    }
+}

--- a/src/Controller/Event/DeleteConfirmation.php
+++ b/src/Controller/Event/DeleteConfirmation.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Event;
+
+use App\Repository\Event\EventRepositoryInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment as Twig;
+
+/**
+ * @Security("is_granted('ROLE_ADMIN')")
+ */
+final class DeleteConfirmation
+{
+    private $repository;
+    private $renderer;
+
+    public function __construct(
+        EventRepositoryInterface $repository,
+        Twig $renderer
+    ) {
+        $this->repository = $repository;
+        $this->renderer = $renderer;
+    }
+
+    public function handle(string $id): Response
+    {
+        if (null === ($event = $this->repository->findById($id))) {
+            throw new NotFoundHttpException(sprintf('The event could not be found this this id %s', $id));
+        }
+
+        return new Response($this->renderer->render('event/confirm_delete.html.twig', [
+            'event' => $event,
+        ]));
+    }
+}

--- a/src/Controller/Event/Edit.php
+++ b/src/Controller/Event/Edit.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Event;
+
+use App\Dto\EventRequest;
+use App\Form\EventType;
+use App\Repository\Event\EventRepositoryInterface;
+use App\Service\FileUploaderInterface;
+use Ramsey\Uuid\Uuid;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\RouterInterface;
+use Twig\Environment as Twig;
+
+final class Edit
+{
+    public const FORM_ACTION = 'edit';
+    private $renderer;
+    private $router;
+    private $formFactory;
+    private $repository;
+    private $fileUploader;
+
+    public function __construct(
+        Twig $renderer,
+        EventRepositoryInterface $repository,
+        FormFactoryInterface $formFactory,
+        RouterInterface $router,
+        FileUploaderInterface $fileUploader
+    ) {
+        $this->renderer = $renderer;
+        $this->repository = $repository;
+        $this->formFactory = $formFactory;
+        $this->router = $router;
+        $this->fileUploader = $fileUploader;
+    }
+
+    /**
+     * @Security("is_granted('ROLE_ADMIN')")
+     */
+    public function handle(Request $request): Response
+    {
+        $id = Uuid::fromString($request->attributes->get('id'))->toString();
+
+        $event = $this->repository->findById($id);
+        if (!$event) {
+            throw new NotFoundHttpException(sprintf('The event could not be found this this id %s', $id));
+        }
+
+        $eventRequest = EventRequest::createFromEvent($event);
+        $form = $this->formFactory->create(EventType::class, $eventRequest, ['method' => 'put']);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $event = $eventRequest->updateEvent($event);
+            $this->repository->save($event);
+
+            return new RedirectResponse($this->router->generate('event_show', [
+                'id' => $event->getId(),
+            ]));
+        }
+
+        return new Response($this->renderer->render('event/create.html.twig', [
+            'event' => $event,
+            'form' => $form->createView(),
+            'action' => self::FORM_ACTION,
+        ]));
+    }
+}

--- a/src/Controller/Event/Index.php
+++ b/src/Controller/Event/Index.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Event;
+
+use App\Repository\Event\EventRepository;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment as Twig;
+
+final class Index
+{
+    private $renderer;
+    private $repository;
+
+    public function __construct(Twig $renderer, EventRepository $repository)
+    {
+        $this->renderer = $renderer;
+        $this->repository = $repository;
+    }
+
+    public function handle(): Response
+    {
+        $eventList = $this->repository->findAll();
+
+        return new Response($this->renderer->render('home.html.twig', ['events' => $eventList]));
+    }
+}

--- a/src/Controller/Event/Select.php
+++ b/src/Controller/Event/Select.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Event;
+
+use App\Repository\Event\EventRepository;
+use App\Service\Event\EventService;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\SessionUnavailableException;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Twig\Environment as Twig;
+
+/**
+ * @Security("is_granted('ROLE_USER')")
+ */
+final class Select
+{
+    private $renderer;
+    private $repository;
+    private $eventService;
+
+    public function __construct(Twig $renderer, EventRepository $repository, EventService $eventService)
+    {
+        $this->renderer = $renderer;
+        $this->repository = $repository;
+        $this->eventService = $eventService;
+    }
+
+    public function handle(Request $request): Response
+    {
+        $eventId = Uuid::fromString($request->attributes->get('id'))->toString();
+
+        if (!$event = $this->repository->findById($eventId)) {
+            throw new NotFoundHttpException(sprintf('The event could not be found this this id %s', $eventId));
+        }
+
+        if (!$this->eventService->isUserLoggedIn()) {
+            throw new SessionUnavailableException('The user is not logged in');
+        }
+
+        $this->eventService->selectEvent($event);
+
+        return new Response($this->renderer->render('event/selected.html.twig', ['event' => $event]));
+    }
+}

--- a/src/Controller/Event/Show.php
+++ b/src/Controller/Event/Show.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Event;
+
+use App\Repository\Event\EventRepositoryInterface;
+use Ramsey\Uuid\Uuid;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Twig\Environment as Twig;
+
+final class Show
+{
+    private $renderer;
+    private $eventRepository;
+
+    public function __construct(Twig $renderer, EventRepositoryInterface $repository)
+    {
+        $this->renderer = $renderer;
+        $this->eventRepository = $repository;
+    }
+
+    /**
+     * @Security("is_granted('ROLE_USER')")
+     */
+    public function handle(Request $request): Response
+    {
+        $id = Uuid::fromString($request->attributes->get('id'))->toString();
+
+        $event = $this->eventRepository->findById($id);
+
+        if (!$event) {
+            throw new NotFoundHttpException();
+        }
+
+        return new Response($this->renderer->render('event/show.html.twig', [
+            'event' => $event,
+        ]));
+    }
+}

--- a/src/Controller/Event/Unselect.php
+++ b/src/Controller/Event/Unselect.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Event;
+
+use App\Service\Event\EventServiceInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\Exception\SessionUnavailableException;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
+
+/**
+ * @Security("is_granted('ROLE_USER')")
+ */
+final class Unselect
+{
+    private $router;
+    private $eventService;
+
+    public function __construct(RouterInterface $renderer, EventServiceInterface $eventService)
+    {
+        $this->router = $renderer;
+        $this->eventService = $eventService;
+    }
+
+    public function handle(): Response
+    {
+        if (!$this->eventService->isUserLoggedIn()) {
+            throw new SessionUnavailableException('The user is not logged in');
+        }
+
+        $this->eventService->unselectEvent();
+
+        return new RedirectResponse($this->router->generate('index'));
+    }
+}

--- a/src/Controller/Home.php
+++ b/src/Controller/Home.php
@@ -4,20 +4,25 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Repository\Event\EventRepository;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment as Twig;
 
 final class Home
 {
     private $renderer;
+    private $eventRepository;
 
-    public function __construct(Twig $renderer)
+    public function __construct(Twig $renderer, EventRepository $eventRepository)
     {
         $this->renderer = $renderer;
+        $this->eventRepository = $eventRepository;
     }
 
     public function handle(): Response
     {
-        return new Response($this->renderer->render('home.html.twig'));
+        $eventList = $this->eventRepository->findAll();
+
+        return new Response($this->renderer->render('home.html.twig', ['events' => $eventList]));
     }
 }

--- a/src/Controller/Space/Create.php
+++ b/src/Controller/Space/Create.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace App\Controller\Space;
 
 use App\Dto\SpaceRequest;
+use App\Exceptions\NoEventSelectedException;
 use App\Form\SpaceType;
+use App\Repository\Schedule\ScheduleRepositoryInterface;
 use App\Repository\Schedule\SpaceRepositoryInterface;
+use App\Service\Event\EventServiceInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -21,17 +24,23 @@ final class Create
     private $renderer;
     private $formFactory;
     private $repository;
+    private $scheduleRepository;
+    private $eventService;
 
     public function __construct(
         Twig $renderer,
         FormFactoryInterface $formFactory,
         RouterInterface $router,
-        SpaceRepositoryInterface $repository
+        SpaceRepositoryInterface $repository,
+        ScheduleRepositoryInterface $scheduleRepository,
+        EventServiceInterface $eventService
     ) {
         $this->renderer = $renderer;
         $this->formFactory = $formFactory;
         $this->router = $router;
         $this->repository = $repository;
+        $this->scheduleRepository = $scheduleRepository;
+        $this->eventService = $eventService;
     }
 
     /**
@@ -39,6 +48,10 @@ final class Create
      */
     public function handle(Request $request): Response
     {
+        if (!$this->eventService->isEventSelected()) {
+            throw new NoEventSelectedException();
+        }
+
         $spaceRequest = new SpaceRequest();
 
         $form = $this->formFactory->create(SpaceType::class, $spaceRequest);

--- a/src/DataFixtures/EventFixture.php
+++ b/src/DataFixtures/EventFixture.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DataFixtures;
+
+use App\Dto\EventRequest;
+use App\Repository\Event\EventRepositoryInterface;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Faker\Factory as Faker;
+
+final class EventFixture extends Fixture implements DependentFixtureInterface
+{
+    private $eventRepository;
+
+    public function __construct(EventRepositoryInterface $eventRepository)
+    {
+        $this->eventRepository = $eventRepository;
+    }
+
+    public function load(ObjectManager $manager): void
+    {
+        $faker = Faker::create();
+
+        $nextAddress = 0;
+
+        for ($iterationCount = 0; $iterationCount < 3; $iterationCount++) {
+            $eventRequest = new EventRequest();
+            $eventRequest->name = $faker->company;
+            $eventRequest->address = $this->getReference('address-'.($nextAddress++));
+            $eventRequest->description = $faker->text(50);
+            $eventRequest->startAt = $faker->dateTimeBetween('2020-01-01', '2020-12-31');
+            $eventRequest->endAt = new \DateTime($eventRequest->startAt->format('Y-m-d'));
+            $eventRequest->endAt->add(new \DateInterval('P3D'));
+
+            $event = $this->eventRepository->createFromRequest($eventRequest);
+            $manager->persist($event);
+        }
+
+        $manager->flush();
+    }
+
+    public function getDependencies(): array
+    {
+        return [
+            AddressFixtures::class,
+        ];
+    }
+}

--- a/src/DataFixtures/ScheduleFixtures.php
+++ b/src/DataFixtures/ScheduleFixtures.php
@@ -4,34 +4,49 @@ declare(strict_types=1);
 
 namespace App\DataFixtures;
 
+use App\Entity\Event;
 use App\Entity\Schedule;
+use App\Repository\Event\EventRepositoryInterface;
 use App\Repository\Schedule\ScheduleRepositoryInterface;
 use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
 use Faker\Factory as Faker;
 
-final class ScheduleFixtures extends Fixture
+final class ScheduleFixtures extends Fixture implements DependentFixtureInterface
 {
     private $scheduleRepository;
+    private $eventRepository;
 
-    public function __construct(ScheduleRepositoryInterface $scheduleRepository)
+    public function __construct(ScheduleRepositoryInterface $scheduleRepository, EventRepositoryInterface $eventRepository)
     {
         $this->scheduleRepository = $scheduleRepository;
+        $this->eventRepository = $eventRepository;
     }
 
     public function load(ObjectManager $manager): void
     {
+        $events = $this->eventRepository->findAll();
         $faker = Faker::create();
 
-        for ($i = 0; $i < 2; $i++) {
-            $schedule = new Schedule();
+        for ($i = 0; $i < 5; $i++) {
+            /** @var Event $selectedEvent */
+            $selectedEvent = $events[$faker->numberBetween(0, count($events) - 1)];
+            $schedule = new Schedule($selectedEvent);
             $schedule->setId(
                 $this->scheduleRepository->nextIdentity()->toString()
             );
-            $schedule->setDay($faker->dateTimeThisMonth);
+            $schedule->setDay($faker->dateTimeBetween($selectedEvent->getStartAt(), $selectedEvent->getEndAt()));
 
             $manager->persist($schedule);
         }
         $manager->flush();
+    }
+
+    public function getDependencies(): array
+    {
+        return [
+            EventFixture::class,
+        ];
     }
 }

--- a/src/Dto/EventRequest.php
+++ b/src/Dto/EventRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\ValueObject\DateRangeInFuture;
+use Symfony\Component\Validator\Constraints as Assert;
+use App\Validator\Constraints as CustomAssert;
+use App\Entity\Event;
+
+final class EventRequest
+{
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Length(min="1", max="100")
+     */
+    public $name;
+
+    public $address;
+
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Date()
+     * @CustomAssert\DateInFuture()
+     * @CustomAssert\DateRange()
+     */
+    public $startAt;
+
+    /**
+     * @Assert\NotBlank()
+     * @Assert\Date()
+     * @CustomAssert\DateInFuture()
+     * @CustomAssert\DateRange()
+     */
+    public $endAt;
+
+    public $description;
+
+    public static function createFromEvent(Event $event): EventRequest
+    {
+        $eventDto = new self();
+        $eventDto->name = $event->getName();
+        $eventDto->description = $event->getDescription();
+        $eventDto->address = $event->getAddress();
+        $eventDto->startAt = $event->getStartAt();
+        $eventDto->endAt = $event->getEndAt();
+
+        return $eventDto;
+    }
+
+    public function updateEvent(Event $event): Event
+    {
+        $event->updateFromRequest($this->name, $this->address, new DateRangeInFuture($this->startAt, $this->endAt), $this->description);
+
+        return $event;
+    }
+}

--- a/src/Entity/Contact.php
+++ b/src/Entity/Contact.php
@@ -55,7 +55,7 @@ class Contact
         $this->addresses = new ArrayCollection();
     }
 
-    public function getId(): ?int
+    public function getId(): string
     {
         return $this->id;
     }

--- a/src/Entity/Event.php
+++ b/src/Entity/Event.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\ValueObject\DateRangeInFuture;
+use Doctrine\ORM\Mapping as ORM;
+use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @ORM\Entity()
+ * @ORM\Table(name="events")
+ */
+class Event
+{
+    /**
+     * @ORM\Id()
+     * @ORM\Column(type="guid")
+     */
+    private $id;
+
+    /**
+     * @Assert\NotBlank()
+     * @ORM\Column(type="string", length=100)
+     */
+    private $name;
+
+    /**
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $description;
+
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    private $startAt;
+
+    /**
+     * @ORM\Column(type="datetime")
+     */
+    private $endAt;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="App\Entity\Address", cascade={"persist", "remove"})
+     */
+    private $address;
+
+    public function __construct(
+        UuidInterface $id,
+        string $name,
+        Address $address,
+        DateRangeInFuture $dateRange,
+        ?string $description = null
+    ) {
+        $this->id = $id->toString();
+        $this->name = $name;
+        $this->address = $address;
+        $this->description = $description;
+        $this->startAt = $dateRange->getStartAt();
+        $this->endAt = $dateRange->getEndAt();
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getAddress(): Address
+    {
+        return $this->address;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function getStartAt(): \DateTimeInterface
+    {
+        return $this->startAt;
+    }
+
+    public function getEndAt(): \DateTimeInterface
+    {
+        return $this->endAt;
+    }
+
+    public function updateFromRequest(
+        string $name,
+        Address $address,
+        DateRangeInFuture $dateRange,
+        ?string $description
+    ): void {
+        $this->name = $name;
+        $this->address = $address;
+        $this->description = $description;
+        $this->startAt = $dateRange->getStartAt();
+        $this->endAt = $dateRange->getEndAt();
+    }
+}

--- a/src/Entity/Organisation.php
+++ b/src/Entity/Organisation.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\UuidInterface;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -42,6 +44,11 @@ class Organisation
      */
     private $comment;
 
+    /**
+     * @ORM\ManyToMany(targetEntity="App\Entity\Event", cascade={"persist", "remove"})
+     */
+    private $events;
+
     public function __construct(UuidInterface $id, string $name, string $website, Contact $contact = null, string $comment = null)
     {
         $this->id = $id->toString();
@@ -49,6 +56,7 @@ class Organisation
         $this->website = $website;
         $this->contact = $contact;
         $this->comment = $comment;
+        $this->events = new ArrayCollection();
     }
 
     public function getId(): ?string
@@ -102,5 +110,15 @@ class Organisation
         $this->comment = $comment;
 
         return $this;
+    }
+
+    public function getEvents(): Collection
+    {
+        return $this->events;
+    }
+
+    public function addSponsoredEvent(Event $event): void
+    {
+        $this->events->add($event);
     }
 }

--- a/src/Entity/Schedule.php
+++ b/src/Entity/Schedule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\Uuid;
 use Ramsey\Uuid\UuidInterface;
@@ -31,8 +32,15 @@ class Schedule
      */
     private $spaces;
 
-    public function __construct()
+    /**
+     * @ORM\OneToOne(targetEntity=Event::class)
+     * @ORM\JoinColumn(name="event_id", referencedColumnName="id")
+     */
+    private $event;
+
+    public function __construct(Event $event)
     {
+        $this->event = $event;
         $this->spaces = new ArrayCollection();
     }
 
@@ -56,7 +64,7 @@ class Schedule
         $this->day = $day;
     }
 
-    public function getSpaces()
+    public function getSpaces(): Collection
     {
         return $this->spaces;
     }
@@ -64,6 +72,11 @@ class Schedule
     public function setSpaces(ArrayCollection $spaces): void
     {
         $this->spaces = $spaces;
+    }
+
+    public function getEvent(): Event
+    {
+        return $this->event;
     }
 
     public function nextIdentity(): UuidInterface

--- a/src/Entity/Speaker.php
+++ b/src/Entity/Speaker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Ramsey\Uuid\UuidInterface;
@@ -35,6 +36,7 @@ class Speaker
         $this->facebook = $facebook;
         $this->linkedin = $linkedin;
         $this->github = $github;
+        $this->events = new ArrayCollection();
     }
 
     /**
@@ -92,6 +94,11 @@ class Speaker
      * @ORM\OneToMany(targetEntity=Talk::class, mappedBy="speaker")
      */
     private $talks;
+
+    /**
+     * @ORM\ManyToMany(targetEntity="App\Entity\Event", cascade={"persist", "remove"}))
+     */
+    private $events;
 
     /**
      * @ORM\Column(type="boolean")
@@ -211,11 +218,6 @@ class Speaker
         return $this;
     }
 
-    public function getTalks(): Collection
-    {
-        return $this->talks;
-    }
-
     public function isInterviewSent(): bool
     {
         return $this->interviewSent;
@@ -229,5 +231,20 @@ class Speaker
     public function confirmInterviewNotSent(): void
     {
         $this->interviewSent = false;
+    }
+
+    public function getTalks(): Collection
+    {
+        return $this->talks;
+    }
+
+    public function getEvents(): Collection
+    {
+        return $this->events;
+    }
+
+    public function addAttendingEvent(Event $event): void
+    {
+        $this->events->add($event);
     }
 }

--- a/src/Exceptions/InvalidDateRangeException.php
+++ b/src/Exceptions/InvalidDateRangeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+class InvalidDateRangeException extends \LogicException
+{
+}

--- a/src/Exceptions/NoEventSelectedException.php
+++ b/src/Exceptions/NoEventSelectedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+class NoEventSelectedException extends \LogicException
+{
+}

--- a/src/Exceptions/PassedDateException.php
+++ b/src/Exceptions/PassedDateException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+class PassedDateException extends \LogicException
+{
+}

--- a/src/Exceptions/Validator/Constraints/NoFormInValidatorException.php
+++ b/src/Exceptions/Validator/Constraints/NoFormInValidatorException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Validator\Constraints;
+
+class NoFormInValidatorException extends \LogicException
+{
+}

--- a/src/Exceptions/Validator/Constraints/UnavailableDateRangePropertiesException.php
+++ b/src/Exceptions/Validator/Constraints/UnavailableDateRangePropertiesException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Validator\Constraints;
+
+class UnavailableDateRangePropertiesException extends \LogicException
+{
+}

--- a/src/Form/AddressType.php
+++ b/src/Form/AddressType.php
@@ -30,6 +30,7 @@ class AddressType extends AbstractType
                 ],
             ])
             ->add('streetAddressComplementary', TextType::class, [
+                'required' => false,
                 'attr' => [
                     'class' => 'form-control',
                     'maxlength' => '127',

--- a/src/Form/EventType.php
+++ b/src/Form/EventType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class EventType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('name', TextType::class, ['required' => true])
+            ->add('description', TextareaType::class, ['required' => false])
+            ->add('address', AddressType::class)
+            ->add('startAt', DateType::class, ['required' => true])
+            ->add('endAt', DateType::class, ['required' => true]);
+    }
+}

--- a/src/Form/ScheduleType.php
+++ b/src/Form/ScheduleType.php
@@ -5,22 +5,28 @@ declare(strict_types=1);
 namespace App\Form;
 
 use App\Dto\ScheduleRequest;
+use App\Service\Event\EventServiceInterface;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class ScheduleType extends AbstractType
 {
+    private $eventService;
+
+    public function __construct(EventServiceInterface $eventService)
+    {
+        $this->eventService = $eventService;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('day', DateType::class, [
+            ->add('day', ChoiceType::class, [
                 'required' => true,
-                'widget' => 'single_text',
-                'html5' => true,
-            ])
-        ;
+                'choices' => $this->getValidDaysForSelectecEvent(),
+                ]);
     }
 
     public function configureOptions(OptionsResolver $resolver): void
@@ -28,5 +34,22 @@ final class ScheduleType extends AbstractType
         $resolver->setDefaults([
             'data_class' => ScheduleRequest::class,
         ]);
+    }
+
+    private function getValidDaysForSelectecEvent(): array
+    {
+        $event = $this->eventService->getSelectedEvent();
+        $period = new \DatePeriod(
+            $event->getStartAt(),
+            new \DateInterval('P1D'),
+            $event->getEndAt()
+        );
+        $availableDays = [];
+        foreach ($period as $oneDay) {
+            $availableDays[$oneDay->format('Y-m-d')] = $oneDay;
+        }
+        $availableDays[$event->getEndAt()->format('Y-m-d')] = $event->getEndAt();
+
+        return $availableDays;
     }
 }

--- a/src/Form/SpaceType.php
+++ b/src/Form/SpaceType.php
@@ -7,6 +7,7 @@ namespace App\Form;
 use App\Entity\Schedule;
 use App\Entity\SpaceType as SpaceTypeEntity;
 use App\Dto\SpaceRequest;
+use App\Repository\Schedule\ScheduleRepositoryInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -16,6 +17,13 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class SpaceType extends AbstractType
 {
+    private $scheduleRepository;
+
+    public function __construct(ScheduleRepositoryInterface $scheduleRepository)
+    {
+        $this->scheduleRepository = $scheduleRepository;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -44,6 +52,7 @@ class SpaceType extends AbstractType
             ])
             ->add('schedule', EntityType::class, [
                 'class' => Schedule::class,
+                'choices' => $this->scheduleRepository->findAllForSelectedEvent(),
                 'choice_label' => function (Schedule $schedule) {
                     return $schedule->getDay()->format('d/m/Y');
                 },

--- a/src/Migrations/AbstractTableNameMigration.php
+++ b/src/Migrations/AbstractTableNameMigration.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Migrations;
+
+use Doctrine\Migrations\AbstractMigration;
+
+abstract class AbstractTableNameMigration extends AbstractMigration
+{
+    protected const SPONSORSHIP_BENEFIT = 'sponsorship_benefit';
+    protected const SPONSORSHIP_LEVEL = 'sponsorship_level';
+    protected const SPONSORSHIP_LEVEL_BENEFIT = 'sponsorship_level_benefit';
+    protected const SPECIAL_BENEFIT = 'special_benefit';
+    protected const SPEAKER = 'speaker';
+    protected const TALK = 'talk';
+    protected const ORGANIZATION = 'organisation';
+    protected const PAGE = 'page';
+    protected const USER = 'app_user';
+    protected const SLOT_TYPE = 'slot_type';
+    protected const SPACE_TYPE = 'space_type';
+    protected const SCHEDULE = 'schedule';
+    protected const SPACE = 'space';
+    protected const SLOT = 'slot';
+    protected const INTERVIEW_QUESTION = 'interview_question';
+    protected const EVENT = 'events';
+    protected const EVENTS_SPEAKERS = 'speaker_event';
+    protected const EVENTS_ORGANIZATIONS = 'organisation_event';
+}

--- a/src/Migrations/Version20190321102134.php
+++ b/src/Migrations/Version20190321102134.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20190321102134 extends AbstractMigration
+{
+    private const TABLE_NAME = 'events';
+
+    public function up(Schema $schema): void
+    {
+        $table = $schema->createTable(self::TABLE_NAME);
+        $table->addColumn('id', Type::GUID);
+        $table->addColumn('name', Type::STRING, ['length' => 100]);
+        $table->addColumn('description', Type::TEXT, ['notnull' => false]);
+        $table->addColumn('address_id', Type::GUID);
+        $table->addColumn('start_at', Type::DATETIME);
+        $table->addColumn('end_at', Type::DATETIME);
+
+        $table->setPrimaryKey(['id']);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable(self::TABLE_NAME);
+    }
+}

--- a/src/Migrations/Version20190325160923.php
+++ b/src/Migrations/Version20190325160923.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use App\Migrations\AbstractTableNameMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+
+final class Version20190325160923 extends AbstractTableNameMigration
+{
+    private const FIELD_EVENT_ID = 'event_id';
+
+    public function up(Schema $schema): void
+    {
+        $tableEventSpeaker = $schema->createTable(self::EVENTS_SPEAKERS);
+        $tableEventSpeaker->addColumn(self::FIELD_EVENT_ID, Type::GUID);
+        $tableEventSpeaker->addColumn('speaker_id', Type::GUID);
+
+        $tableEventSpeaker->setPrimaryKey([self::FIELD_EVENT_ID, 'speaker_id']);
+        $tableEventSpeaker->addForeignKeyConstraint(self::EVENT, [self::FIELD_EVENT_ID], ['id'], ['onDelete' => 'CASCADE']);
+        $tableEventSpeaker->addForeignKeyConstraint(self::SPEAKER, ['speaker_id'], ['id'], ['onDelete' => 'CASCADE']);
+
+        $tableEventOrganization = $schema->createTable(self::EVENTS_ORGANIZATIONS);
+        $tableEventOrganization->addColumn(self::FIELD_EVENT_ID, Type::GUID);
+        $tableEventOrganization->addColumn('organisation_id', Type::GUID);
+
+        $tableEventOrganization->setPrimaryKey([self::FIELD_EVENT_ID, 'organisation_id']);
+        $tableEventOrganization->addForeignKeyConstraint(self::EVENT, [self::FIELD_EVENT_ID], ['id'], ['onDelete' => 'CASCADE']);
+        $tableEventOrganization->addForeignKeyConstraint(self::ORGANIZATION, ['organisation_id'], ['id'], ['onDelete' => 'CASCADE']);
+
+        $tableSchedule = $schema->getTable(self::SCHEDULE);
+        $tableSchedule->addColumn(self::FIELD_EVENT_ID, Type::GUID, ['notnull' => false]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $schema->dropTable(self::EVENTS_SPEAKERS);
+
+        $schema->dropTable(self::EVENTS_ORGANIZATIONS);
+
+        $tableSchedule = $schema->getTable(self::SCHEDULE);
+        $tableSchedule->dropColumn(self::FIELD_EVENT_ID);
+    }
+}

--- a/src/Repository/Event/EventRepository.php
+++ b/src/Repository/Event/EventRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository\Event;
+
+use App\Dto\EventRequest;
+use App\Entity\Event;
+use App\ValueObject\DateRangeInFuture;
+use Doctrine\ORM\EntityManagerInterface;
+use Ramsey\Uuid\Uuid;
+use Ramsey\Uuid\UuidInterface;
+
+final class EventRepository implements EventRepositoryInterface
+{
+    private $entityManager;
+    private $repository;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+        $this->repository = $entityManager->getRepository(Event::class);
+    }
+
+    public function createFromRequest(EventRequest $eventRequest): Event
+    {
+        return new Event(
+            $this->nextIdentity(),
+            $eventRequest->name,
+            $eventRequest->address,
+            new DateRangeInFuture($eventRequest->startAt, $eventRequest->endAt),
+            $eventRequest->description
+        );
+    }
+
+    public function nextIdentity(): UuidInterface
+    {
+        return Uuid::uuid4();
+    }
+
+    public function save(Event $event): void
+    {
+        $this->entityManager->persist($event);
+        $this->entityManager->flush();
+    }
+
+    public function findAll(): array
+    {
+        return $this->repository->findAll();
+    }
+
+    public function findById(string $id): ?Event
+    {
+        return $this->repository->find($id);
+    }
+
+    public function remove(Event $event): void
+    {
+        $this->entityManager->remove($event);
+        $this->entityManager->flush();
+    }
+}

--- a/src/Repository/Event/EventRepositoryInterface.php
+++ b/src/Repository/Event/EventRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository\Event;
+
+use App\Dto\EventRequest;
+use App\Entity\Event;
+use Ramsey\Uuid\UuidInterface;
+
+interface EventRepositoryInterface
+{
+    public function createFromRequest(EventRequest $eventRequest): Event;
+
+    public function nextIdentity(): UuidInterface;
+
+    public function save(Event $event): void;
+
+    public function remove(Event $event): void;
+
+    public function findAll(): array;
+
+    public function findById(string $id): ?Event;
+}

--- a/src/Repository/Schedule/ScheduleRepositoryInterface.php
+++ b/src/Repository/Schedule/ScheduleRepositoryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository\Schedule;
 
 use App\Dto\ScheduleRequest;
+use App\Entity\Event;
 use App\Entity\Schedule;
 use Ramsey\Uuid\UuidInterface;
 
@@ -22,13 +23,18 @@ interface ScheduleRepositoryInterface
      */
     public function findBy(array $criteria = [], array $orderBy = [], int $limit = null, int $offset = null): array;
 
-    public function createFrom(ScheduleRequest $scheduleRequest): Schedule;
+    public function createFrom(Event $event, ScheduleRequest $scheduleRequest): Schedule;
 
     public function nextIdentity(): UuidInterface;
 
     public function save(Schedule $schedule): void;
 
     public function remove(Schedule $schedule): void;
+
+    /**
+     * @return Schedule[]
+     */
+    public function findAllForSelectedEvent(): array;
 
     public function duplicate(Schedule $schedule): void;
 }

--- a/src/Repository/Schedule/SpaceRepository.php
+++ b/src/Repository/Schedule/SpaceRepository.php
@@ -37,6 +37,11 @@ final class SpaceRepository implements SpaceRepositoryInterface
         return $this->repository->findAll();
     }
 
+    public function findBy(array $criteria = [], array $orderBy = [], int $limit = null, int $offset = null): array
+    {
+        return $this->repository->findBy($criteria, $orderBy, $limit, $offset);
+    }
+
     public function createFrom(SpaceRequest $spaceRequest): Space
     {
         $space = new Space();

--- a/src/Repository/Schedule/SpaceRepositoryInterface.php
+++ b/src/Repository/Schedule/SpaceRepositoryInterface.php
@@ -24,4 +24,6 @@ interface SpaceRepositoryInterface
     public function save(Space $space): void;
 
     public function remove(Space $space): void;
+
+    public function findBy(array $criteria = [], array $orderBy = [], int $limit = null, int $offset = null): array;
 }

--- a/src/Security/LoginFormAuthenticator.php
+++ b/src/Security/LoginFormAuthenticator.php
@@ -93,7 +93,7 @@ final class LoginFormAuthenticator extends AbstractFormLoginAuthenticator
             return new RedirectResponse($targetPath);
         }
 
-        return new RedirectResponse($this->router->generate('login_success'));
+        return new RedirectResponse($this->router->generate('index'));
     }
 
     public function getLoginUrl()

--- a/src/Service/Event/EventService.php
+++ b/src/Service/Event/EventService.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Event;
+
+use App\Entity\Event;
+use App\Exceptions\NoEventSelectedException;
+use App\Repository\Event\EventRepositoryInterface;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+final class EventService implements EventServiceInterface
+{
+    public const EVENT_ID = 'event-id';
+    public const EVENT_NAME = 'event-name';
+    private $session;
+    private $eventRepository;
+
+    public function __construct(SessionInterface $session, EventRepositoryInterface $eventRepository)
+    {
+        $this->session = $session;
+        $this->eventRepository = $eventRepository;
+    }
+
+    public function getSelectedEventName(): string
+    {
+        if (!$this->session->has(self::EVENT_NAME)) {
+            throw new NoEventSelectedException();
+        }
+
+        return $this->session->get(self::EVENT_NAME);
+    }
+
+    public function getSelectedEventId(): string
+    {
+        if (!$this->session->has(self::EVENT_ID)) {
+            throw new NoEventSelectedException();
+        }
+
+        return $this->session->get(self::EVENT_ID);
+    }
+
+    public function selectEvent(Event $event): void
+    {
+        $this->session->set(self::EVENT_NAME, $event->getName());
+        $this->session->set(self::EVENT_ID, $event->getId());
+    }
+
+    public function isUserLoggedIn(): bool
+    {
+        return $this->session->isStarted();
+    }
+
+    public function unselectEvent(): void
+    {
+        $this->session->remove(self::EVENT_ID);
+        $this->session->remove(self::EVENT_NAME);
+    }
+
+    public function isEventSelected(): bool
+    {
+        return $this->session->has(self::EVENT_ID);
+    }
+
+    public function getSelectedEvent(): Event
+    {
+        if (!$this->session->has(self::EVENT_ID)) {
+            throw new NoEventSelectedException();
+        }
+
+        return $this->eventRepository->findById($this->session->get(self::EVENT_ID));
+    }
+}

--- a/src/Service/Event/EventServiceInterface.php
+++ b/src/Service/Event/EventServiceInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Event;
+
+use App\Entity\Event;
+
+interface EventServiceInterface
+{
+    public function getSelectedEventName(): ?string;
+
+    public function getSelectedEventId(): ?string;
+
+    public function getSelectedEvent(): ?Event;
+
+    public function selectEvent(Event $event): void;
+
+    public function unselectEvent(): void;
+
+    public function isUserLoggedIn(): bool;
+
+    public function isEventSelected(): bool;
+}

--- a/src/Validator/Constraints/DateInFuture.php
+++ b/src/Validator/Constraints/DateInFuture.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+final class DateInFuture extends Constraint
+{
+    public $message = 'The date "{{ date }}" cannot be set in the past.';
+}

--- a/src/Validator/Constraints/DateInFutureValidator.php
+++ b/src/Validator/Constraints/DateInFutureValidator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+final class DateInFutureValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof DateInFuture) {
+            throw new UnexpectedTypeException($constraint, DateInFuture::class);
+        }
+
+        if (null === $value || '' === $value || (!$value instanceof \DateTimeInterface)) {
+            return;
+        }
+
+        if ($value < (new \DateTime('now'))) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ date }}', $value->format('M d Y'))
+                ->addViolation();
+        }
+    }
+}

--- a/src/Validator/Constraints/DateRange.php
+++ b/src/Validator/Constraints/DateRange.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+final class DateRange extends Constraint
+{
+    public $message = 'Start date "{{ startDate }}" cannot be higher than end date "{{ endDate }}".';
+}

--- a/src/Validator/Constraints/DateRangeValidator.php
+++ b/src/Validator/Constraints/DateRangeValidator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator\Constraints;
+
+use App\Exceptions\Validator\Constraints\NoFormInValidatorException;
+use App\Exceptions\Validator\Constraints\UnavailableDateRangePropertiesException;
+use Symfony\Component\Form\Form;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+
+final class DateRangeValidator extends ConstraintValidator
+{
+    public function validate($value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof DateRange) {
+            throw new UnexpectedTypeException($constraint, DateRange::class);
+        }
+
+        $form = $this->context->getRoot();
+
+        if (!$form instanceof Form) {
+            throw new NoFormInValidatorException('Validator need to retrieve a Symfony form to work');
+        }
+
+        $dtoRequest = $form->getViewData();
+        if (!property_exists($dtoRequest, 'startAt') && !property_exists($dtoRequest, 'endAt')) {
+            throw new UnavailableDateRangePropertiesException('Validator DateRange need two public parameters to work, DateTimeInterface startAt and DateTimeInterface endAt');
+        }
+
+        if ($dtoRequest->startAt > $dtoRequest->endAt) {
+            $this->context->buildViolation($constraint->message)
+                ->setParameter('{{ startDate }}', $dtoRequest->startAt->format('M d Y'))
+                ->setParameter('{{ endDate }}', $dtoRequest->endAt->format('M d Y'))
+                ->addViolation();
+        }
+    }
+}

--- a/src/ValueObject/DateRangeInFuture.php
+++ b/src/ValueObject/DateRangeInFuture.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ValueObject;
+
+use App\Exceptions\InvalidDateRangeException;
+use App\Exceptions\PassedDateException;
+
+final class DateRangeInFuture
+{
+    private $startAt;
+    private $endAt;
+
+    public function __construct(\DateTimeInterface $startAt, \DateTimeInterface $endAt)
+    {
+        if ($startAt > $endAt) {
+            throw new InvalidDateRangeException(sprintf('start At %s cannot be higher than end At %s',
+                $startAt->format('Y-m-d'),
+                $endAt->format('Y-m-d')
+            ));
+        }
+
+        if ($startAt < (new \DateTime())) {
+            throw new PassedDateException(sprintf('The date %s cannot be in the past', $startAt->format('Y-m-d')));
+        }
+
+        $this->startAt = $startAt;
+        $this->endAt = $endAt;
+    }
+
+    public function getStartAt(): \DateTimeInterface
+    {
+        return $this->startAt;
+    }
+
+    public function getEndAt(): \DateTimeInterface
+    {
+        return $this->endAt;
+    }
+
+    public function getDuration(): \DateInterval
+    {
+        return $this->endAt->diff($this->startAt);
+    }
+}

--- a/templates/event/_delete_form.html.twig
+++ b/templates/event/_delete_form.html.twig
@@ -1,0 +1,5 @@
+<form method="post" action="{{ path('event_delete', {'id': event.id}) }}" class="d-inline-block">
+    <input type="hidden" name="_method" value="DELETE">
+    <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ event.id) }}">
+    <button type="submit" class="btn btn-danger">Delete</button>
+</form>

--- a/templates/event/confirm_delete.html.twig
+++ b/templates/event/confirm_delete.html.twig
@@ -1,0 +1,28 @@
+{% extends "base.html.twig" %}
+
+{% block title %}Delete event{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col text-center">
+            <h1 class="mb-lg-4 mt-lg-4">Delete event</h1>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-6 offset-3">
+            <div class="card">
+                <div class="card-body text-center">
+                    <h5 class="card-title">Do you wish to confirm "{{ event.name }}" event deletion?</h5>
+                    <div class="row mt-5">
+                        <div class="col-6">
+                            <a href="{{ path('index') }}" class="btn btn-light">Back to list</a>
+                        </div>
+                        <div class="col-6">
+                            {{ include('event/_delete_form.html.twig') }}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/event/create.html.twig
+++ b/templates/event/create.html.twig
@@ -1,0 +1,36 @@
+{% extends "base.html.twig" %}
+{% if action is defined and action == constant('App\\Controller\\Event\\Edit::FORM_ACTION') %}
+    {% set titlePage = 'Edit event' %}
+    {% set submitButton = 'Save changes' %}
+{% else %}
+    {% set titlePage = 'New event' %}
+    {% set submitButton = 'Create Event' %}
+{% endif %}
+
+{% block title %}{{ titlePage }}{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col-12 text-center text-sm-left">
+            <h1>{{ titlePage }}</h1>
+        </div>
+    </div>
+
+    {{ form_start(form) }}
+    <div class="row">
+        <div class="col-12">
+            {{ form_widget(form) }}
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-6">
+            <a href="{{ path('index') }}" class="btn btn-light">Back to home</a>
+        </div>
+        <div class="col-6 text-right">
+            <button type="submit" class="btn btn-success float-right">{{ submitButton }}</button>
+        </div>
+    </div>
+    {{ form_end(form) }}
+{% endblock %}
+
+

--- a/templates/event/selected.html.twig
+++ b/templates/event/selected.html.twig
@@ -1,0 +1,17 @@
+{% extends "base.html.twig" %}
+
+{% block stylesheets %}
+    <link rel="stylesheet" href="{{ asset('build/app.css') }}"/>
+{% endblock %}
+
+{% block title %}Event selected{% endblock %}
+
+{% block content %}
+    <div class="container">
+        <p>You have selected the {{ event.name }} event, you can now start to manage it.</p>
+        <p>If you want to end the management of this event,
+            go to your home page by clicking at "{{ event.name }} management in progress"
+            and choose "Finish management".</p>
+        <p>After this action you will be able to choose or create another event.</p>
+    </div>
+{% endblock %}

--- a/templates/event/show.html.twig
+++ b/templates/event/show.html.twig
@@ -1,0 +1,59 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Event{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col-12">
+            <h1>Event</h1>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-12">
+            <table class="table">
+                <tbody>
+                <tr>
+                    <th>Name</th>
+                    <td>{{ event.name }}</td>
+                </tr>
+                <tr>
+                    <th>Address</th>
+                    <td>
+                    {{ event.address.streetAddress }}<br />
+                    {{ event.address.streetAddressComplementary }}<br />
+                    {{ event.address.postalCode }} {{ event.address.city }} </td>
+                </tr>
+                <tr>
+                    <th>Description</th>
+                    <td>{{ event.description }}</td>
+                </tr>
+                <tr>
+                    <th>Start At</th>
+                    <td>{{ event.startAt|date('j F Y') }}</td>
+                </tr>
+                <tr>
+                    <th>End At</th>
+                    <td>{{ event.endAt|date('j F Y') }}</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="row mb-3">
+        <div class="col-5">
+            <a href="{{ path('index') }}" class="btn btn-light">Back to home</a>
+        </div>
+        <div class="col-7 text-right">
+            {% if is_granted('ROLE_ADMIN') %}
+                {% if not app.session.has('event-id') %}
+                    <a href="{{ path('event_edit', {'id': event.id}) }}" class="btn btn-warning">Edit</a>
+                    <a href="{{ path('event_confirm_delete', {'id': event.id}) }}" class="btn btn-danger">Delete</a>
+                {% else %}
+                    <p style="color: red">To edit or delete this event, you need to <a href="{{ path('event_unselect') }}">finish management</a> first.</p>
+                {% endif %}
+            {% endif %}
+        </div>
+    </div>
+{% endblock %}

--- a/templates/home.html.twig
+++ b/templates/home.html.twig
@@ -7,3 +7,65 @@
      <h1>Community event manager</h1>
 </div>
 {% endblock %}
+
+{% block content %}
+     {% if is_granted('ROLE_USER') %}
+          <div class="row">
+               <div class="col-sm-6 text-center text-sm-left">
+                    <h2>Events management</h2>
+               </div>
+               {% if is_granted('ROLE_ADMIN') and not app.session.has('event-id') %}
+                    <div class="col-sm-6 text-center text-sm-right">
+                         <a class="btn btn-primary" href="{{ path('event_create') }}">Create a new Event</a>
+                    </div>
+               {% elseif is_granted('ROLE_USER') and app.session.has('event-id') %}
+                    <div class="col-sm-6 text-center text-sm-right">
+                         <a class="btn btn-primary" href="{{ path('event_unselect') }}">Finish management on {{ app.session.get('event-name') }}</a>
+                    </div>
+               {% endif %}
+          </div>
+     {% endif %}
+
+     {% if events|default(false) and is_granted('ROLE_USER') and not app.session.has('event-id') %}
+          <div class="row mt-3">
+               <div class="col-12 table-responsive-sm">
+                    <table class="table table-striped">
+                         <thead>
+                              <tr>
+                                   <th>Name</th>
+                                   <th>Start Date</th>
+                                   <th>End Date</th>
+                                   <th class="text-center">Actions</th>
+                              </tr>
+                         </thead>
+                         <tbody>
+                              {% for event in events %}
+                                   <tr>
+                                        <td><a class="btn btn-info mb-2 mb-md-0" href="{{ path('event_select', {'id': event.id}) }}">Select {{ event.name }}</a></td>
+                                        <td>{{ event.startAt|date('j F Y') }}</td>
+                                        <td>{{ event.endAt|date('j F Y') }}</td>
+                                        <td class="text-center">
+                                             <a class="btn btn-info mb-2 mb-md-0"
+                                                href="{{ path('event_show', {'id': event.id}) }}">Details</a>
+                                             {% if is_granted('ROLE_ADMIN') %}
+                                                  <a class="btn btn-warning mb-2 mb-md-0"
+                                                     href="{{ path('event_edit', {'id': event.id}) }}">Edit</a>
+                                                  <a class="btn btn-danger mb-2 mb-md-0"
+                                                     href="{{ path('event_confirm_delete', {'id': event.id}) }}">
+                                                       Delete
+                                                  </a>
+                                             {% endif %}
+                                        </td>
+                                   </tr>
+                              {% else %}
+                                   <tr>
+                                        <td colspan="3">no events are created yet</td>
+                                   </tr>
+                              {% endfor %}
+                         </tbody>
+                    </table>
+               </div>
+          </div>
+
+     {% endif %}
+{% endblock %}

--- a/templates/layout/header.html.twig
+++ b/templates/layout/header.html.twig
@@ -5,27 +5,23 @@
             <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="navbar-toggle">
-            <a class="navbar-brand" href="{{ path('index') }}">Community Event Manager</a>
+            {% if app.session.has('event-id') and is_granted('ROLE_USER') %}
+                <a class="navbar-brand" href="{{ path('index') }}">{{ app.session.get('event-name') }} management in progress</a>
+                <a class="btn btn-info mb-2 mb-md-0"
+                   href="{{ path('event_show', {'id': app.session.get('event-id')}) }}">Details</a>
+            {% else %}
+                <a class="navbar-brand" href="{{ path('index') }}">Community Event Manager</a>
+            {% endif %}
             <ul class="navbar-nav ml-auto mt-2 mt-lg-0">
                 {% if is_granted('ROLE_USER') %}
                     <li class="nav-item dropdown
-                        {{ app.request.attributes.get('_route') matches '#^(organisation)#' ? 'active' }}">
+                        {{ app.request.attributes.get('_route') matches '#^(organisation|speaker|talk)#' ? 'active' }}">
                         <a class="nav-link dropdown-toggle" id="crm-dropdown" role="button" data-toggle="dropdown"
                            aria-haspopup="true" aria-expanded="false">
                             CRM
                         </a>
                         <div class="dropdown-menu" aria-labelledby="crm-dropdown">
                             <a class="dropdown-item" href="{{ path('organisation_list') }}">Organisations</a>
-                        </div>
-                    </li>
-                    <li class="nav-item dropdown
-                        {{ app.request.attributes.get('_route') matches '#^(speaker|talk)#' ? 'active' }}">
-                        <a class="nav-link dropdown-toggle" id="schedule-dropdown" role="button" data-toggle="dropdown"
-                           aria-haspopup="true" aria-expanded="false">
-                            Schedule
-                        </a>
-                        <div class="dropdown-menu" aria-labelledby="schedule-dropdown">
-                            <a class="dropdown-item" href="{{ path('schedule_index') }}">Schedule</a>
                             <a class="dropdown-item" href="{{ path('speaker_index') }}">Speakers</a>
                             <a class="dropdown-item" href="{{ path('talk_index') }}">Talks</a>
                             <a class="dropdown-item" href="{{ path('schedule_space_type_index') }}">Space types</a>
@@ -35,23 +31,35 @@
                             <a class="dropdown-item" href="{{ path('interview_question_index') }}">Interview questions</a>
                         </div>
                     </li>
-                    <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle
-                           {{ app.request.attributes.get('_route') matches '#^(sponsorship_|special_benefit)#' ? 'active' }}"
-                           id="sponsorship-dropdown" role="button" data-toggle="dropdown"
-                           aria-haspopup="true" aria-expanded="false">
-                            Sponsorships
-                        </a>
-                        <div class="dropdown-menu" aria-labelledby="sponsorship-dropdown">
-                            <a class="dropdown-item" href="{{ path('sponsorship_level_index') }}">Levels</a>
-                            <a class="dropdown-item" href="{{ path('sponsorship_benefit_index') }}">Benefits</a>
-                            <a class="dropdown-item" href="{{ path('sponsorship_level_benefit_view') }}">Summary</a>
-                            <div class="dropdown-divider"></div>
-                            <a class="dropdown-item" href="{{ path('special_benefit_index') }}">Special</a>
-                            <a class="dropdown-item" href="{{ path('page_index') }}">Pages</a>
-                            <a class="dropdown-item" href="{{ path('sponsorships_pdf') }}">Brochure PDF</a>
-                        </div>
-                    </li>
+                    {% if app.session.has('event-id') %}
+                        <li class="nav-item dropdown
+                            {{ app.request.attributes.get('_route') matches '#^(schedule)#' ? 'active' }}">
+                            <a class="nav-link dropdown-toggle" id="schedule-dropdown" role="button" data-toggle="dropdown"
+                               aria-haspopup="true" aria-expanded="false">
+                                Schedule
+                            </a>
+                            <div class="dropdown-menu" aria-labelledby="schedule-dropdown">
+                                <a class="dropdown-item" href="{{ path('schedule_index') }}">Schedule</a>
+                            </div>
+                        </li>
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle
+                               {{ app.request.attributes.get('_route') matches '#^(sponsorship_|special_benefit)#' ? 'active' }}"
+                               id="sponsorship-dropdown" role="button" data-toggle="dropdown"
+                               aria-haspopup="true" aria-expanded="false">
+                                Sponsorships
+                            </a>
+                            <div class="dropdown-menu" aria-labelledby="sponsorship-dropdown">
+                                <a class="dropdown-item" href="{{ path('sponsorship_level_index') }}">Levels</a>
+                                <a class="dropdown-item" href="{{ path('sponsorship_benefit_index') }}">Benefits</a>
+                                <a class="dropdown-item" href="{{ path('sponsorship_level_benefit_view') }}">Summary</a>
+                                <div class="dropdown-divider"></div>
+                                <a class="dropdown-item" href="{{ path('special_benefit_index') }}">Special</a>
+                                <a class="dropdown-item" href="{{ path('page_index') }}">Pages</a>
+                                <a class="dropdown-item" href="{{ path('sponsorships_pdf') }}">Brochure PDF</a>
+                            </div>
+                        </li>
+                    {% endif %}
                 {% endif %}
                 {% if not is_granted('IS_AUTHENTICATED_FULLY') %}
                     <li class="nav-item 'active'">

--- a/templates/organisations/show.html.twig
+++ b/templates/organisations/show.html.twig
@@ -48,6 +48,16 @@
                     <th>Comment</th>
                     <td>{{ organisation.comment | default('N/A') }}</td>
                 </tr>
+                <tr>
+                    <th>Sponsored Events</th>
+                    <td>
+                        <ul>
+                            {% for event in organisation.events %}
+                                <li>{{ event.name }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </td>
+                </tr>
                 </tbody>
             </table>
         </div>

--- a/templates/speaker/show.html.twig
+++ b/templates/speaker/show.html.twig
@@ -64,6 +64,17 @@
                         </ul>
                     </td>
                 </tr>
+
+                <tr>
+                    <th>Attending Events</th>
+                    <td>
+                        <ul>
+                            {% for event in speaker.events %}
+                                <li>{{ event.name }}</a></li>
+                            {% endfor %}
+                        </ul>
+                    </td>
+                </tr>
                 </tbody>
             </table>
         </div>


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | yes <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   |  Yes <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | #103    <!-- #-prefixed issue number(s), if any -->

# Description

Add event management in homepage with CRUD option when a user is connected to admin.

A user can select a created event and this will open a session with the event id to manage. Once an event is selected, the project pages change to be linked to this event.

One event is linked to a lot of part of the project, schedule part has been updated to be linked to specific event management, but there is still a lot to do to complete the event management ( to be made in other issues as this one issue embark too many changes already)

- Add speakers attending to an event. => issue #155 
- Add organizations sponsoring an event. => issue #156
- Link all sponsorship part to one event only. => issue #157
- Be able to link an organization to become a sponsor with a specific level.

NB: this list can be updated.