### PR TITLE
Error 500 when deleting slot type that is currently used

### DIFF
--- a/src/Controller/SlotType/Delete.php
+++ b/src/Controller/SlotType/Delete.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Controller\SlotType;
 
+use App\Repository\Schedule\SlotRepository;
 use App\Repository\Schedule\SlotTypeRepositoryInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
@@ -16,20 +18,39 @@ final class Delete
     private $slotTypeRepository;
     private $router;
     private $csrfTokenManager;
+    private $flashBag;
+    private $slotRepository;
 
     public function __construct(
         SlotTypeRepositoryInterface $slotTypeRepository,
         RouterInterface $router,
-        CsrfTokenManagerInterface $csrfTokenManager
+        CsrfTokenManagerInterface $csrfTokenManager,
+        FlashBagInterface $flashBag,
+        SlotRepository $slotRepository
     ) {
         $this->slotTypeRepository = $slotTypeRepository;
         $this->router = $router;
         $this->csrfTokenManager = $csrfTokenManager;
+        $this->flashBag = $flashBag;
+        $this->slotRepository = $slotRepository;
     }
 
     public function handle(Request $request): RedirectResponse
     {
         $slotType = $this->slotTypeRepository->find($request->attributes->get('id'));
+
+        $slots = $this->slotRepository->findBy([
+            'type' => $slotType,
+        ]);
+
+        if ($slots) {
+            $this->flashBag->add(
+                'error',
+                sprintf('"%s" is currently used in schedule and cannot be deleted', $slotType->getDescription())
+            );
+
+            return new RedirectResponse($this->router->generate('schedule_slot_type_index'));
+        }
 
         $token = new CsrfToken('delete'.$slotType->getId(), $request->request->get('_token'));
         if ($this->csrfTokenManager->isTokenValid($token)) {


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | yes <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | no <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | #148    <!-- #-prefixed issue number(s), if any -->

# Description

An error message will be displayed when we try to delete a slot type already use.

![image](https://user-images.githubusercontent.com/14071317/55404792-f9ec3280-5558-11e9-810e-d75bfd1104f7.png)
