### PR TITLE
[Fixes #150] Prevent anonymous users to generate PDF file

### DIFF
--- a/features/brochure.feature
+++ b/features/brochure.feature
@@ -1,0 +1,7 @@
+Feature: Brochure
+  Generate a semi-automatic brochure about my event
+  that I can publish and share.
+
+  Scenario: Trying to generate brochure PDF when being anonymous
+    When I am on "/sponsorships/pdf"
+    Then I should be on "/login/"

--- a/src/Controller/GeneratePdf.php
+++ b/src/Controller/GeneratePdf.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use App\Repository\Page\PageManagerInterface;
 use App\Repository\SpecialBenefit\SpecialBenefitManagerInterface;
 use App\Repository\SponsorshipLevel\SponsorshipLevelManagerInterface;
@@ -41,6 +42,9 @@ final class GeneratePdf
         $this->specialBenefitManager = $specialBenefitManager;
     }
 
+    /**
+     * @Security("is_granted('ROLE_ADMIN')")
+     */
     public function handle(): Response
     {
         $pages = $this->pageManager->findAll();


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | yes
| New feature?  | no
| Tests pass?   | yes
| Related issue | #150 

# Description

Put brochure PDF generation route behind firewall to prevent anonymous to generate and access PDF.