### PR TITLE
Add CI test to check whether migrations are up to date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ script:
     - docker-compose run composer bin/phpunit
     - docker-compose exec php vendor/bin/behat --format progress --strict
     - docker-compose exec php vendor/bin/php-cs-fixer fix --verbose --diff --dry-run
+    - make check_migrations_updated

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,14 @@ test:
 	docker-compose run php vendor/bin/behat
 
 check_migrations_updated:
-	docker-compose exec php bin/console doctrine:schema:update --dump-sql | grep "Nothing to update"
+	@if docker-compose exec php bin/console doctrine:schema:update --dump-sql | grep "Nothing to update"; then \
+		echo "OK, Schema is up to date with schema mapping."; \
+	else \
+		echo "Migrations are not up to date with schema mapping."; \
+		echo "Here are SQL missing in migrations:"; \
+		docker-compose exec php bin/console doctrine:schema:update --dump-sql; \
+		return false; \
+	fi
 
 logs:
 	docker-compose logs -ft

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ test:
 	docker-compose run composer ./vendor/bin/simple-phpunit
 	docker-compose run php vendor/bin/behat
 
+check_migrations_updated:
+	docker-compose exec php bin/console doctrine:schema:update --dump-sql | grep "Nothing to update"
+
 logs:
 	docker-compose logs -ft
 

--- a/src/Entity/Schedule.php
+++ b/src/Entity/Schedule.php
@@ -33,7 +33,7 @@ class Schedule
     private $spaces;
 
     /**
-     * @ORM\OneToOne(targetEntity=Event::class)
+     * @ORM\ManyToOne(targetEntity=Event::class)
      * @ORM\JoinColumn(name="event_id", referencedColumnName="id")
      */
     private $event;

--- a/src/Entity/SponsorshipLevel.php
+++ b/src/Entity/SponsorshipLevel.php
@@ -41,7 +41,7 @@ class SponsorshipLevel
     private $sponsorshipLevelBenefits;
 
     /**
-     * @ORM\Column(type="integer")
+     * @ORM\Column(type="integer", nullable=true)
      */
     private $position;
 

--- a/src/Migrations/Version20190325160923.php
+++ b/src/Migrations/Version20190325160923.php
@@ -18,7 +18,7 @@ final class Version20190325160923 extends AbstractTableNameMigration
         $tableEventSpeaker->addColumn(self::FIELD_EVENT_ID, Type::GUID);
         $tableEventSpeaker->addColumn('speaker_id', Type::GUID);
 
-        $tableEventSpeaker->setPrimaryKey([self::FIELD_EVENT_ID, 'speaker_id']);
+        $tableEventSpeaker->setPrimaryKey(['speaker_id', self::FIELD_EVENT_ID]);
         $tableEventSpeaker->addForeignKeyConstraint(self::EVENT, [self::FIELD_EVENT_ID], ['id'], ['onDelete' => 'CASCADE']);
         $tableEventSpeaker->addForeignKeyConstraint(self::SPEAKER, ['speaker_id'], ['id'], ['onDelete' => 'CASCADE']);
 
@@ -26,12 +26,13 @@ final class Version20190325160923 extends AbstractTableNameMigration
         $tableEventOrganization->addColumn(self::FIELD_EVENT_ID, Type::GUID);
         $tableEventOrganization->addColumn('organisation_id', Type::GUID);
 
-        $tableEventOrganization->setPrimaryKey([self::FIELD_EVENT_ID, 'organisation_id']);
+        $tableEventOrganization->setPrimaryKey(['organisation_id', self::FIELD_EVENT_ID]);
         $tableEventOrganization->addForeignKeyConstraint(self::EVENT, [self::FIELD_EVENT_ID], ['id'], ['onDelete' => 'CASCADE']);
         $tableEventOrganization->addForeignKeyConstraint(self::ORGANIZATION, ['organisation_id'], ['id'], ['onDelete' => 'CASCADE']);
 
         $tableSchedule = $schema->getTable(self::SCHEDULE);
         $tableSchedule->addColumn(self::FIELD_EVENT_ID, Type::GUID, ['notnull' => false]);
+        $tableSchedule->addForeignKeyConstraint(self::EVENT, [self::FIELD_EVENT_ID], ['id']);
     }
 
     public function down(Schema $schema): void

--- a/src/Migrations/Version20190405145553.php
+++ b/src/Migrations/Version20190405145553.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190405145553 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('DROP SEQUENCE speaker_id_seq CASCADE');
+        $this->addSql('DROP SEQUENCE address_id_seq CASCADE');
+        $this->addSql('DROP SEQUENCE contact_id_seq CASCADE');
+        $this->addSql('ALTER TABLE space_type ALTER name TYPE VARCHAR(255)');
+        $this->addSql('ALTER TABLE address ALTER name DROP NOT NULL');
+        $this->addSql('ALTER TABLE space ALTER type_id DROP NOT NULL');
+        $this->addSql('ALTER TABLE space ALTER schedule_id DROP NOT NULL');
+        $this->addSql('DROP INDEX uniq_e6e132b4bf396750');
+        $this->addSql('ALTER TABLE events ALTER address_id DROP NOT NULL');
+        $this->addSql('ALTER TABLE events ADD CONSTRAINT FK_5387574AF5B7AF75 FOREIGN KEY (address_id) REFERENCES address (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_5387574AF5B7AF75 ON events (address_id)');
+        $this->addSql('ALTER TABLE speaker ALTER interview_sent DROP DEFAULT');
+        $this->addSql('ALTER TABLE sponsorship_level_benefit ALTER content TYPE VARCHAR(255)');
+        $this->addSql('ALTER TABLE sponsorship_level_benefit ALTER content DROP DEFAULT');
+        $this->addSql('DROP INDEX idx_ac0e20676f0601d5');
+        $this->addSql('ALTER TABLE slot ALTER type_id DROP NOT NULL');
+        $this->addSql('ALTER TABLE slot ALTER space_id DROP NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_AC0E20676F0601D5 ON slot (talk_id)');
+        $this->addSql('DROP INDEX uniq_9f24d5bbbf396750');
+        $this->addSql('ALTER TABLE talk ALTER speaker_id DROP NOT NULL');
+        $this->addSql('ALTER TABLE talk ADD CONSTRAINT FK_9F24D5BBD04A0F27 FOREIGN KEY (speaker_id) REFERENCES speaker (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_9F24D5BBD04A0F27 ON talk (speaker_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('CREATE SEQUENCE speaker_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE SEQUENCE address_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE SEQUENCE contact_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('ALTER TABLE speaker ALTER interview_sent SET DEFAULT \'false\'');
+        $this->addSql('ALTER TABLE talk DROP CONSTRAINT FK_9F24D5BBD04A0F27');
+        $this->addSql('DROP INDEX IDX_9F24D5BBD04A0F27');
+        $this->addSql('ALTER TABLE talk ALTER speaker_id SET NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX uniq_9f24d5bbbf396750 ON talk (id)');
+        $this->addSql('ALTER TABLE sponsorship_level_benefit ALTER content TYPE TEXT');
+        $this->addSql('ALTER TABLE sponsorship_level_benefit ALTER content DROP DEFAULT');
+        $this->addSql('CREATE UNIQUE INDEX uniq_e6e132b4bf396750 ON organisation (id)');
+        $this->addSql('ALTER TABLE space_type ALTER name TYPE VARCHAR(100)');
+        $this->addSql('ALTER TABLE space ALTER type_id SET NOT NULL');
+        $this->addSql('ALTER TABLE space ALTER schedule_id SET NOT NULL');
+        $this->addSql('DROP INDEX UNIQ_AC0E20676F0601D5');
+        $this->addSql('ALTER TABLE slot ALTER type_id SET NOT NULL');
+        $this->addSql('ALTER TABLE slot ALTER space_id SET NOT NULL');
+        $this->addSql('CREATE INDEX idx_ac0e20676f0601d5 ON slot (talk_id)');
+        $this->addSql('ALTER TABLE address ALTER name SET NOT NULL');
+        $this->addSql('ALTER TABLE events DROP CONSTRAINT FK_5387574AF5B7AF75');
+        $this->addSql('DROP INDEX IDX_5387574AF5B7AF75');
+        $this->addSql('ALTER TABLE events ALTER address_id SET NOT NULL');
+    }
+}


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | yes
| New feature?  | no
| Tests pass?   | yes
| Related issue | nope

## Description

Database schema is not synced with entities mapping.

This is because there is some options missing in migrations like nullable, missing indexes...

So This PR adds a new script in CI to check if after running migrations, schema is sync with entities mapping.

If the job fails, it displays the following result:

```
$ make check_migrations_updated
docker-compose exec php bin/console doctrine:schema:update --dump-sql | grep "Nothing to update"
make: *** [check_migrations_updated] Error 1
The command "make check_migrations_updated" exited with 2.
cache.2

Done. Your build exited with 1.
```

### To test it

- Locally, run `make check_migrations_updated`, it should display nothing if ok, or display error if not.
- Also you can check result Travis.