### PR TITLE
[Fixes #162] Edit sponsorship level set position to null

### DIFF
--- a/src/Controller/SponsorshipLevel/Edit.php
+++ b/src/Controller/SponsorshipLevel/Edit.php
@@ -49,6 +49,7 @@ final class Edit
 
         if ($form->isSubmitted() && $form->isValid()) {
             $sponsorshipLevelRequest = $form->getData();
+            $sponsorshipLevelRequest->position = $sponsorshipLevel->getPosition();
             $sponsorshipLevelRequest->updateEntity($sponsorshipLevel);
             $this->sponsorshipLevelManager->save($sponsorshipLevel);
 

--- a/src/Entity/SponsorshipLevel.php
+++ b/src/Entity/SponsorshipLevel.php
@@ -41,7 +41,7 @@ class SponsorshipLevel
     private $sponsorshipLevelBenefits;
 
     /**
-     * @ORM\Column(type="integer", nullable=true)
+     * @ORM\Column(type="integer")
      */
     private $position;
 

--- a/src/Migrations/Version20190409103447.php
+++ b/src/Migrations/Version20190409103447.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190409103447 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE sponsorship_level ALTER "position" SET NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE sponsorship_level ALTER position DROP NOT NULL');
+    }
+}

--- a/src/Repository/SponsorshipLevel/SponsorshipLevelRepository.php
+++ b/src/Repository/SponsorshipLevel/SponsorshipLevelRepository.php
@@ -54,7 +54,7 @@ final class SponsorshipLevelRepository extends ServiceEntityRepository implement
 
     public function findAll(): array
     {
-        return parent::findAll();
+        return parent::findBy([], ['position' => 'ASC']);
     }
 
     public function findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null): array


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop
| Bug fix?      | yes
| New feature?  | no
| Tests pass?   | yes
| Related issue | #162 


- Fixes Entity schema to make position not nullable, and add migration
- Prevent level position reset when editing its label
- Make sponsorships level `findAll` returns levels ordered by position