### PR TITLE
Fix error when adding talk - Fix #178

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -14,6 +14,7 @@ default:
         - InterviewQuestionContext
         - SendInterviewContext
         - EventContext
+        - TalkContext
   extensions:
     Behat\Symfony2Extension:
       kernel:

--- a/features/bootstrap/TalkContext.php
+++ b/features/bootstrap/TalkContext.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\MinkExtension\Context\RawMinkContext;
+use App\DataFixtures\SpeakerFixtures;
+
+final class TalkContext extends RawMinkContext
+{
+    private const PATH_TALK = '/talks/';
+    
+    /**
+     * @When /^I am on the talk listing page$/
+     */
+    public function iAmOnTheTalkListingPage(): void
+    {
+        $this->visitPath(self::PATH_TALK);
+    }
+
+    /**
+     * @When /^I am on the talk creation page$/
+     */
+    public function iAmOnTheTalkCreationPage(): void
+    {
+        $this->visitPath(self::PATH_TALK.'create');
+    }
+
+    /**
+     * @Then /^I should be redirected on the talk listing page$/
+     */
+    public function iShouldBeRedirectedOnTheTalkListingPage(): void
+    {
+        $this->assertSession()->addressEquals($this->locatePath(self::PATH_TALK));
+    }
+
+    /**
+     * @When /^I fill the talk "([^"]*)" field with "([^"]*)"$/
+     */
+    public function iFillTheTalkFieldWith(string $field, string $value): void
+    {
+        if ("speaker" === $field) {
+            if (isset(SpeakerFixtures::DEFAULT_SPEAKER[$value])) {
+                $value = SpeakerFixtures::DEFAULT_SPEAKER[$value];
+            } else {
+                throw new Exception('Value don\'t exist');
+            }
+        }
+        
+        $field = $this->fixStepArgument(sprintf('talk[%s]', $field));
+        $value = $this->fixStepArgument($value);
+        $this->getSession()->getPage()->fillField($field, $value);
+    }
+
+    /**
+     * @When /^I fill the talk "([^"]*)" "([^"]*)" address field with "([^"]*)"$/
+     */
+    public function iFillTheTalkAddressFieldWith(string $field, string $period, string $value): void
+    {
+        $field = $this->fixStepArgument(sprintf("event[%s][%s]", $field, $period));
+        $this->getSession()->getPage()->fillField($field, $value);
+    }
+
+    private function fixStepArgument(string $argument): string
+    {
+        return str_replace('\\"', '"', $argument);
+    }
+}

--- a/features/talk.feature
+++ b/features/talk.feature
@@ -1,0 +1,22 @@
+Feature: Talk Selection
+    In order to test CRUD on Talk
+    As an admin
+    I need to be able to list all task and fill forms
+
+  Scenario: I don't add an talk and go back to home
+    Given I am logged in as an admin
+    When I am on the talk creation page
+    And I fill the talk "title" field with "My best Talk dependency injection"
+    And I fill the talk "description" field with "In this talk i can speak the dependancy injection"
+    And I fill the talk "speaker" field with "Behat"
+    And I click "Back to list" link
+    
+
+  Scenario: I add an talk
+    Given I am logged in as an admin
+    When I am on the talk creation page
+    And I fill the talk "title" field with "My best Talk dependency injection"
+    And I fill the talk "description" field with "In this talk i can speak the dependancy injection"
+    And I fill the talk "speaker" field with "Behat"
+    And I press "Add talk"
+ 

--- a/src/Controller/Talk/Create.php
+++ b/src/Controller/Talk/Create.php
@@ -34,7 +34,7 @@ final class Create
     }
 
     /**
-     * @Security("is_granted('ROROLE_ADMIN')")
+     * @Security("is_granted('ROLE_ADMIN')")
      */
     public function handle(Request $request): Response
     {

--- a/src/DataFixtures/SpeakerFixtures.php
+++ b/src/DataFixtures/SpeakerFixtures.php
@@ -20,6 +20,9 @@ final class SpeakerFixtures extends Fixture implements DependentFixtureInterface
     private $speakerRepository;
     private $eventRepository;
     private $fileUploader;
+    public const DEFAULT_SPEAKER = [
+        'Behat' => '82e7325c-36b3-4c33-a0e8-743c6013e008',
+    ];
 
     public function __construct(
         SpeakerRepositoryInterface $speakerRepository,


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | yes <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | no <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    i would like improve its
| Related issue | #178   <!-- #-prefixed issue number(s), if any -->

# Description
~~I can create new talk with admin roles. I fix its.~~
Fixes the bug #178 where an administrator was not able to add a new talk by enforcing the right RBAC (by fixing the existing typo).