### PR TITLE
[Fixes #202] Add 'Fixes #...' in PR template to automatically close related issue when PR merged

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 | Bug fix?      | yes/no <!-- don't forget to update the CHANGELOG.md files -->
 | New feature?  | yes/no <!-- don't forget to update the CHANGELOG.md files -->
 | Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
-| Related issue | #   <!-- #-prefixed issue number(s), if any -->
+| Related issue | Fixes #   <!-- #-prefixed issue number(s), if any -->
 
 # Description
 


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | no <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | Fixes #202   <!-- #-prefixed issue number(s), if any -->

# Description

Update github PR template to add `Fixes #...` so that issue tagged here will be automatically closed when PR is merged.