### PR TITLE
Fixes #208  add "set" keyword to permission settings for minio/events directory

### DIFF
--- a/docker/minio/create-bucket.sh
+++ b/docker/minio/create-bucket.sh
@@ -5,4 +5,4 @@ export $(grep -v '^#' .env | xargs)
 /usr/bin/mc config host add minio http://storage:9000 ${S3_KEY} ${S3_SECRET};
 /usr/bin/mc rm -r --force minio/events;
 /usr/bin/mc mb minio/events;
-/usr/bin/mc policy download minio/events;
+/usr/bin/mc policy set download minio/events;


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | yes <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | no <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | Fixes #208    <!-- #-prefixed issue number(s), if any -->

# Description

The command for the create-bucket.sh used by minio during the build has been changed.

Previously it was "/usr/bin/mc policy download minio/events;" and it was needed to be changed by 
"/usr/bin/mc policy **set** download minio/events;" as the minio docker container has been updated recently, we can assume the old writing must have been deprecated for a while and just get deleted permanently