### PR TITLE
Monolog is only required in dev dependencies

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -11,7 +11,7 @@ return [
     Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
-    Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
+    Symfony\Bundle\MonologBundle\MonologBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
     FOS\JsRoutingBundle\FOSJsRoutingBundle::class => ['all' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | no <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | #212      <!-- #-prefixed issue number(s), if any -->

# Description

Monolog is only required in dev yet, so it can't work in prod