### PR TITLE
hide title field on slot form when slot type is talk

### DIFF
--- a/assets/js/schedule/slot/add_slot.js
+++ b/assets/js/schedule/slot/add_slot.js
@@ -3,11 +3,19 @@ function displayTalk() {
 
     if (slotType === "Talk") {
         $("#slot_talk").closest(".form-group").removeClass("d-none");
+        $("#slot_title").closest(".form-group").addClass("d-none");
+        $("#slot_title").val("");
         return;
     }
 
     $("#slot_talk").closest(".form-group").addClass("d-none");
     $("#slot_talk").val("");
+    $("#slot_title").closest(".form-group").removeClass("d-none");
+}
+
+function setTitleFromTalk() {
+    const selectedTalk = $("#slot_talk option:selected").html();
+    $("#slot_title").val(selectedTalk);
 }
 
 $(document).ready(function() {
@@ -16,4 +24,8 @@ $(document).ready(function() {
 
 $("#slot_type").change(function() {
     displayTalk();
+});
+
+$("#slot_talk").change(function() {
+    setTitleFromTalk();
 });

--- a/assets/js/schedule/slot/edit_slot.js
+++ b/assets/js/schedule/slot/edit_slot.js
@@ -3,11 +3,19 @@ function displayTalk() {
 
     if (slotType === "Talk") {
         $("#slot_talk").closest(".form-group").removeClass("d-none");
+        $("#slot_title").closest(".form-group").addClass("d-none");
+        $("#slot_title").val("");
         return;
     }
 
     $("#slot_talk").closest(".form-group").addClass("d-none");
     $("#slot_talk").val("");
+    $("#slot_title").closest(".form-group").removeClass("d-none");
+}
+
+function setTitleFromTalk() {
+    const selectedTalk = $("#slot_talk option:selected").html();
+    $("#slot_title").val(selectedTalk);
 }
 
 $(document).ready(function() {
@@ -16,4 +24,8 @@ $(document).ready(function() {
 
 $("#slot_type").change(function() {
     displayTalk();
+});
+
+$("#slot_talk").change(function() {
+    setTitleFromTalk();
 });


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | no <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | Fixes #216  <!-- #-prefixed issue number(s), if any -->

# Description

While adding/editing a slot, if slot type is talk then user has to select the talk (from the talk list dropdown) as well as write the title there which is redundant.

With this PR, if the slot type is talk, then title field will be hidden and the selected talk's string will be used as the title of slot.