### PR TITLE
Fix Title value object

### DIFF
--- a/src/ValueObject/Title.php
+++ b/src/ValueObject/Title.php
@@ -9,12 +9,13 @@ use App\Exceptions\ValueObject\Title\UnableToCreateTitleException;
 final class Title
 {
     public const MIN_LENGTH = 5;
-    public const MAX_LENGTH = 5;
+    public const MAX_LENGTH = 50;
+
     private $title;
 
     public function __construct(string $title)
     {
-        if (5 >= strlen($title) && 50 <= strlen($title)) {
+        if (self::MIN_LENGTH >= strlen($title) && self::MAX_LENGTH <= strlen($title)) {
             throw new UnableToCreateTitleException(
                 sprintf('Title length is %d and does not match the requested range from %d to %d.', strlen($title), self::MIN_LENGTH, self::MAX_LENGTH)
             );


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | yes <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | no <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | no

# Description

In the Title value object, there are two constants to fix the length range of the string. However, this constants were used only in the Exception message and the if statement used harcoded values instead.

I replaced this harcoded value with the constants and change the value of the MAX_LENGTH to match the old hardcoded one.