### PR TITLE
Add HTTP constants in the controllers

### DIFF
--- a/src/Controller/InterviewQuestion/Edit.php
+++ b/src/Controller/InterviewQuestion/Edit.php
@@ -43,7 +43,7 @@ final class Edit
         $interviewQuestionRequest = InterviewQuestionRequest::createFromInterviewQuestion($interviewQuestion);
 
         $form = $this->formFactory->create(InterviewQuestionType::class, $interviewQuestionRequest, [
-            'method' => 'put',
+            'method' => Request::METHOD_PUT,
         ]);
         $form->handleRequest($request);
 

--- a/src/Controller/Organisation/Edit.php
+++ b/src/Controller/Organisation/Edit.php
@@ -48,7 +48,7 @@ final class Edit
 
         $organisationRequest = OrganisationRequest::createFrom($organisation);
         $form = $this->formFactory->create(OrganisationType::class, $organisationRequest, [
-            'method' => 'PUT',
+            'method' => Request::METHOD_PUT,
         ]);
         $form->handleRequest($request);
 

--- a/src/Controller/Page/Edit.php
+++ b/src/Controller/Page/Edit.php
@@ -49,7 +49,7 @@ final class Edit
         $backgroundPath = $pageRequest->backgroundPath;
 
         $form = $this->formFactory->create(PageType::class, $pageRequest, [
-            'method' => 'put',
+            'method' => Request::METHOD_PUT,
         ]);
         $form->handleRequest($request);
 

--- a/src/Controller/SlotType/Edit.php
+++ b/src/Controller/SlotType/Edit.php
@@ -39,7 +39,7 @@ final class Edit
         $slotTypeRequest = SlotTypeRequest::createFromEntity($slotType);
 
         $form = $this->formFactory->create(SlotTypeType::class, $slotTypeRequest, [
-            'method' => 'put',
+            'method' => Request::METHOD_PUT,
         ]);
         $form->handleRequest($request);
 

--- a/src/Controller/SpecialBenefit/Edit.php
+++ b/src/Controller/SpecialBenefit/Edit.php
@@ -43,7 +43,7 @@ final class Edit
         $specialBenefitRequest = SpecialBenefitRequest::createFromEntity($specialBenefit);
 
         $form = $this->formFactory->create(SpecialBenefitType::class, $specialBenefitRequest, [
-            'method' => 'put',
+            'method' => Request::METHOD_PUT,
         ]);
         $form->handleRequest($request);
 

--- a/src/Controller/SponsorshipBenefit/Edit.php
+++ b/src/Controller/SponsorshipBenefit/Edit.php
@@ -43,7 +43,7 @@ final class Edit
         $sponsorshipBenefitRequest = SponsorshipBenefitRequest::createFromEntity($sponsorshipBenefit);
 
         $form = $this->formFactory->create(SponsorshipBenefitType::class, $sponsorshipBenefitRequest, [
-            'method' => 'put',
+            'method' => Request::METHOD_PUT,
         ]);
         $form->handleRequest($request);
 

--- a/src/Controller/SponsorshipLevel/Edit.php
+++ b/src/Controller/SponsorshipLevel/Edit.php
@@ -43,7 +43,7 @@ final class Edit
         $sponsorshipLevelRequest = SponsorshipLevelRequest::createFromEntity($sponsorshipLevel);
 
         $form = $this->formFactory->create(SponsorshipLevelType::class, $sponsorshipLevelRequest, [
-            'method' => 'put',
+            'method' => Request::METHOD_PUT,
         ]);
         $form->handleRequest($request);
 


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | yes <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | Fixes #226    <!-- #-prefixed issue number(s), if any -->

# Description

In all controllers, the HTTP method value is hard-coded
example: 'method' => 'put'
the best would be replaced this value by a constant like this :
'method' => Request::METHOD_PUT