### PR TITLE
Remove duplication knp-paginator in symfony.lock

### DIFF
--- a/symfony.lock
+++ b/symfony.lock
@@ -203,9 +203,6 @@
     "league/csv": {
         "version": "9.2.0"
     },
-    "knplabs/knp-paginator-bundle": {
-        "version": "v3.0.0"
-    },
     "league/flysystem": {
         "version": "1.0.48"
     },


### PR DESCRIPTION
# PR information

| Q             | A
| ------------- | ---
| Branch?       | Develop <!-- to be replaced if the merge is not on develop, if so, explain why -->
| Bug fix?      | no <!-- don't forget to update the CHANGELOG.md files -->
| New feature?  | yes <!-- don't forget to update the CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers, follow the contributing.md file for more informations -->
| Related issue | Fixes #228    <!-- #-prefixed issue number(s), if any -->

# Description

Remove duplication `knp-paginator-bundle` in `symfony.lock`